### PR TITLE
Add segmented Simple CMS geometry

### DIFF
--- a/gdml-generator/CMakeLists.txt
+++ b/gdml-generator/CMakeLists.txt
@@ -28,7 +28,7 @@ set(core_src
 
 set(geo_src
   ${geo_dir}/BoxDetector.cc
-  ${geo_dir}/SimpleCMSDetector.cc
+  ${geo_dir}/SimpleCmsDetector.cc
   ${geo_dir}/SegmentedSimpleCmsDetector.cc
   ${geo_dir}/TestEm3Detector.cc
 )

--- a/gdml-generator/CMakeLists.txt
+++ b/gdml-generator/CMakeLists.txt
@@ -29,6 +29,7 @@ set(core_src
 set(geo_src
   ${geo_dir}/BoxDetector.cc
   ${geo_dir}/SimpleCMSDetector.cc
+  ${geo_dir}/SegmentedSimpleCmsDetector.cc
   ${geo_dir}/TestEm3Detector.cc
 )
 

--- a/gdml-generator/README.md
+++ b/gdml-generator/README.md
@@ -15,7 +15,11 @@ $ cmake ..; make
 
 # Run
 ```shell
-$ ./gdml-gen [geometry_enum] [optional production_cuts_mm (default is 0.7)]
+$ ./gdml-gen [geometry_enum]
+```
+For the segmented simple cms, the number of segments are also needed:
+```shell
+$ ./gdml-gen [3 or 4] [num_segments_r] [num_segments_theta] [num_segments_z]
 ```
 
 The available geometries are:
@@ -25,15 +29,17 @@ The available geometries are:
 | 0    | `G4_Pb` cube of 500 m side ("infinite") |
 | 1    | Simple CMS with simple materials |
 | 2    | Simple CMS with composite materials |
-| 3    | [TestEm3][testem3] with simple materials |
-| 4    | [TestEm3][testem3] with composite materials |
-| 5    | Flattened [TestEm3][testem3] with simple materials (for ORANGE only) |
-| 6    | Flattened [TestEm3][testem3] with simple materials (for ORANGE only) |
+| 3    | Segmented simple CMS with simple materials |
+| 4    | Segmented simple CMS with composite materials |
+| 5    | [TestEm3][testem3] with simple materials |
+| 6    | [TestEm3][testem3] with composite materials |
+| 7    | Flattened [TestEm3][testem3] with simple materials (for ORANGE only) |
+| 8    | Flattened [TestEm3][testem3] with simple materials (for ORANGE only) |
 
 [testem3]: https://github.com/apt-sim/AdePT/tree/master/examples/TestEm3
 
 Secondary production cut thresholds are set equally for protons, electrons,
-positrons, and gammas and are in **[mm]**.
+positrons, and gammas and are are set to 0.7 **[mm]**.
 
 
 # Adding new geometries

--- a/gdml-generator/gdml-gen.cc
+++ b/gdml-generator/gdml-gen.cc
@@ -132,6 +132,19 @@ int main(int argc, char* argv[])
         return EXIT_FAILURE;
     }
 
+    // Load input parameters
+    auto const geometry_id = static_cast<GeometryID>(std::stoi(argv[1]));
+    double const range_cuts = 0.7;
+    // double const range_cuts = (argc == 3) ? std::stod(argv[2]) : 0.7;
+
+    if (geometry_id != GeometryID::segmented_simple_cms
+        && geometry_id != GeometryID::segmented_simple_cms_composite
+        && argc != 2)
+    {
+        std::cout << "Wrong number of arguments" << std::endl;
+        return EXIT_FAILURE;
+    }
+
     // Create Run Manager
     std::unique_ptr<G4RunManager> run_manager;
 #if G4_V10
@@ -140,11 +153,6 @@ int main(int argc, char* argv[])
     run_manager.reset(
         G4RunManagerFactory::CreateRunManager(G4RunManagerType::Serial));
 #endif
-
-    // Load input parameters
-    auto const geometry_id = static_cast<GeometryID>(std::stoi(argv[1]));
-    double const range_cuts = 0.7;
-    // double const range_cuts = (argc == 3) ? std::stod(argv[2]) : 0.7;
 
     using CMSType = SimpleCmsDetector::MaterialType;
     using SCMSType = SegmentedSimpleCmsDetector::MaterialType;

--- a/gdml-generator/gdml-gen.cc
+++ b/gdml-generator/gdml-gen.cc
@@ -25,7 +25,7 @@
 
 #include "BoxDetector.hh"
 #include "SegmentedSimpleCmsDetector.hh"
-#include "SimpleCMSDetector.hh"
+#include "SimpleCmsDetector.hh"
 #include "TestEm3Detector.hh"
 #include "core/PhysicsList.hh"
 
@@ -146,7 +146,7 @@ int main(int argc, char* argv[])
     double const range_cuts = 0.7;
     // double const range_cuts = (argc == 3) ? std::stod(argv[2]) : 0.7;
 
-    using CMSType = SimpleCMSDetector::MaterialType;
+    using CMSType = SimpleCmsDetector::MaterialType;
     using SCMSType = SegmentedSimpleCmsDetector::MaterialType;
     using TestEm3MatType = TestEm3Detector::MaterialType;
     using TestEm3GeoType = TestEm3Detector::GeometryType;
@@ -162,13 +162,13 @@ int main(int argc, char* argv[])
 
         case GeometryID::simple_cms:
             run_manager->SetUserInitialization(
-                new SimpleCMSDetector(CMSType::simple));
+                new SimpleCmsDetector(CMSType::simple));
             gdml_filename = "simple-cms.gdml";
             break;
 
         case GeometryID::simple_cms_composite:
             run_manager->SetUserInitialization(
-                new SimpleCMSDetector(CMSType::composite));
+                new SimpleCmsDetector(CMSType::composite));
             gdml_filename = "composite-simple-cms.gdml";
             break;
 

--- a/gdml-generator/gdml-gen.cc
+++ b/gdml-generator/gdml-gen.cc
@@ -124,54 +124,61 @@ int main(int argc, char* argv[])
             run_manager->SetUserInitialization(new BoxDetector());
             gdml_filename = "box.gdml";
             break;
+
         case GeometryID::simple_cms:
             run_manager->SetUserInitialization(
                 new SimpleCMSDetector(CMSType::simple));
             gdml_filename = "simple-cms.gdml";
             break;
+
         case GeometryID::simple_cms_composite:
             run_manager->SetUserInitialization(
                 new SimpleCMSDetector(CMSType::composite));
             gdml_filename = "composite-simple-cms.gdml";
             break;
+
         case GeometryID::segmented_simple_cms:
             SegmentedSimpleCmsDetector::SegmentDefinition def;
             def.num_r = 2;
             def.num_theta = 20;
-            def.num_z = 1;
+            def.num_z = 3;
             run_manager->SetUserInitialization(
                 new SegmentedSimpleCmsDetector(SCMSType::composite, def));
             gdml_filename = "composite-segmented-simple-cms.gdml";
             break;
+
         case GeometryID::testem3:
             run_manager->SetUserInitialization(new TestEm3Detector(
                 TestEm3MatType::simple, TestEm3GeoType::hierarchical));
             gdml_filename = "testem3.gdml";
             break;
+
         case GeometryID::testem3_composite:
             run_manager->SetUserInitialization(new TestEm3Detector(
                 TestEm3MatType::composite, TestEm3GeoType::hierarchical));
             gdml_filename = "testem3-composite.gdml";
             break;
+
         case GeometryID::testem3_flat:
             run_manager->SetUserInitialization(new TestEm3Detector(
                 TestEm3MatType::simple, TestEm3GeoType::flat));
             gdml_filename = "testem3-flat.gdml";
             break;
+
         case GeometryID::testem3_composite_flat:
             run_manager->SetUserInitialization(new TestEm3Detector(
                 TestEm3MatType::composite, TestEm3GeoType::flat));
             gdml_filename = "testem3-flat-composite.gdml";
             break;
+
         default:
             std::cout << (int)geometry_id << " is an invalid geometry id."
                       << std::endl;
             return EXIT_FAILURE;
     }
 
-    // Load phisics list, particle gun, and initialize run manager
+    // Load phisics list and initialize run manager
     run_manager->SetUserInitialization(new PhysicsList(range_cuts));
-    // run_manager->SetUserInitialization(new ActionInitialization());
     run_manager->Initialize();
     run_manager->RunInitialization();
 

--- a/gdml-generator/src/SegmentedSimpleCmsDetector.cc
+++ b/gdml-generator/src/SegmentedSimpleCmsDetector.cc
@@ -22,7 +22,7 @@
 
 //---------------------------------------------------------------------------//
 /*!
- * Construct with geometry type enum.
+ * Construct with geometry type enum and number of segments.
  */
 SegmentedSimpleCmsDetector::SegmentedSimpleCmsDetector(
     MaterialType type, SegmentDefinition segments)
@@ -127,8 +127,8 @@ SegmentedSimpleCmsDetector::build_materials()
 /*!
  * Programmatic geometry definition: Segmented simple CMS mock up.
  *
- * This is a set of single-element concentric cylinders that acts as a
- * cylindrical cow in a vacuum version of CMS.
+ * This is a set of single-element concentric cylinders that can be split
+ * multiple times in each direction, to generate a large numbers of volumes.
  *
  * - The World volume is a box, and its dimensions are expressed in cartesian
  * coordinates [x. y, z].
@@ -145,20 +145,12 @@ SegmentedSimpleCmsDetector::build_materials()
  * | superconducting solenoid     | Ti               | [275, 375, 1400]   |
  * | muon chambers                | Fe               | [375, 700, 1400]   |
  *
- * - Different distances between volumes are set so that geometry navigation
- * can be tested. These values are defined in \c volume_gaps_ . Current
- * configuration uses:
+ * Table shows the full cylinder values. Each of those cylinders can be
+ * segmented in every direction. The sum of all segments will add up to the
+ * above values.
  *
- * | Volume                       | Gap type   |
- * | ---------------------------- | ---------- |
- * | world                        | N/A        |
- * | vacuum tube                  | tolerance  |
- * | silicon tracker              | tolerance  |
- * | electromagnetic calorimeter  | overlap    |
- * | hadron calorimeter           | overlap    |
- * | superconducting solenoid     | millimeter |
- * | muon chambers                | N/A        |
- *
+ * E.g.: If the silicon tracker is segmented in 2 in the radial axis, it will
+ * become si_tracker_1 (r = [30, 77.5]) and si_tracker_2 (r = [77.5, 125]).
  */
 G4VPhysicalVolume* SegmentedSimpleCmsDetector::segmented_simple_cms()
 {

--- a/gdml-generator/src/SegmentedSimpleCmsDetector.cc
+++ b/gdml-generator/src/SegmentedSimpleCmsDetector.cc
@@ -16,6 +16,7 @@
 #include <G4PVReplica.hh>
 #include <G4SDManager.hh>
 #include <G4VisAttributes.hh>
+#include <stdlib.h>
 
 #include "core/SensitiveDetector.hh"
 
@@ -27,6 +28,14 @@ SegmentedSimpleCmsDetector::SegmentedSimpleCmsDetector(
     MaterialType type, SegmentDefinition segments)
     : geometry_type_(type), num_segments_(segments)
 {
+    if (num_segments_.num_r < 1 || num_segments_.num_theta < 1
+        || num_segments_.num_z < 1)
+    {
+        std::cout << "Number of segments must be at least 1 in every axis"
+                  << std::endl;
+        exit(EXIT_FAILURE);
+    }
+
     materials_ = this->build_materials();
 }
 

--- a/gdml-generator/src/SegmentedSimpleCmsDetector.cc
+++ b/gdml-generator/src/SegmentedSimpleCmsDetector.cc
@@ -1,0 +1,425 @@
+//----------------------------------*-C++-*----------------------------------//
+// Copyright 2023 UT-Battelle, LLC, and other Celeritas developers.
+// See the top-level COPYRIGHT file for details.
+// SPDX-License-Identifier: (Apache-2.0 OR MIT)
+//---------------------------------------------------------------------------//
+//! \file SegmentedSimpleCmsDetector.cc
+//---------------------------------------------------------------------------//
+#include "SegmentedSimpleCmsDetector.hh"
+
+#include <G4Box.hh>
+#include <G4Colour.hh>
+#include <G4LogicalVolume.hh>
+#include <G4NistManager.hh>
+#include <G4PVPlacement.hh>
+#include <G4PVReplica.hh>
+#include <G4SDManager.hh>
+#include <G4Tubs.hh>
+#include <G4VisAttributes.hh>
+
+#include "core/SensitiveDetector.hh"
+
+//---------------------------------------------------------------------------//
+/*!
+ * Construct with geometry type enum.
+ */
+SegmentedSimpleCmsDetector::SegmentedSimpleCmsDetector(
+    MaterialType type, SegmentDefinition segments)
+    : geometry_type_(type), num_segments_(segments)
+{
+}
+
+//---------------------------------------------------------------------------//
+/*!
+ * Mandatory Construct function.
+ */
+G4VPhysicalVolume* SegmentedSimpleCmsDetector::Construct()
+{
+    return this->segmented_simple_cms();
+}
+
+//---------------------------------------------------------------------------//
+/*!
+ * Set sensitive detectors and (TODO) magnetic field.
+ */
+void SegmentedSimpleCmsDetector::ConstructSDandField()
+{
+    this->set_sd();
+
+    // TODO: Add magnetic field
+}
+
+//---------------------------------------------------------------------------//
+// PRIVATE
+//---------------------------------------------------------------------------//
+
+//---------------------------------------------------------------------------//
+/*!
+ * Define list of materials.
+ */
+SegmentedSimpleCmsDetector::MaterialList
+SegmentedSimpleCmsDetector::build_materials()
+{
+    MaterialList materials;
+    G4NistManager* nist = G4NistManager::Instance();
+
+    switch (geometry_type_)
+    {
+        case MaterialType::simple:
+            // Load materials
+            materials.world = nist->FindOrBuildMaterial("G4_Galactic");
+            materials.vacuum_tube = nist->FindOrBuildMaterial("G4_Galactic");
+            materials.si_tracker = nist->FindOrBuildMaterial("G4_Si");
+            materials.em_calorimeter = nist->FindOrBuildMaterial("G4_Pb");
+            materials.had_calorimeter = nist->FindOrBuildMaterial("G4_C");
+            materials.sc_solenoid = nist->FindOrBuildMaterial("G4_Ti");
+            materials.muon_chambers = nist->FindOrBuildMaterial("G4_Fe");
+
+            // Update names
+            materials.world->SetName("vacuum");
+            materials.vacuum_tube->SetName("vacuum");
+            materials.si_tracker->SetName("Si");
+            materials.em_calorimeter->SetName("Pb");
+            materials.had_calorimeter->SetName("C");
+            materials.sc_solenoid->SetName("Ti");
+            materials.muon_chambers->SetName("Fe");
+            break;
+
+        case MaterialType::composite:
+            // Load materials
+            materials.world = nist->FindOrBuildMaterial("G4_Galactic");
+            materials.vacuum_tube = nist->FindOrBuildMaterial("G4_Galactic");
+            materials.si_tracker
+                = nist->FindOrBuildMaterial("G4_SILICON_DIOXIDE");
+            materials.em_calorimeter
+                = nist->FindOrBuildMaterial("G4_LEAD_OXIDE");
+            materials.had_calorimeter = nist->FindOrBuildMaterial("G4_C");
+            materials.sc_solenoid = nist->FindOrBuildMaterial("G4_Ti");
+            materials.muon_chambers = nist->FindOrBuildMaterial("G4_Fe");
+
+            // Update names
+            materials.world->SetName("vacuum");
+            materials.vacuum_tube->SetName("vacuum");
+            materials.si_tracker->SetName("SiO2");
+            materials.em_calorimeter->SetName("Pb3O4");
+            materials.had_calorimeter->SetName("C");
+            materials.sc_solenoid->SetName("Ti");
+            materials.muon_chambers->SetName("Fe");
+            break;
+        default:
+            break;
+    }
+
+    return materials;
+}
+
+//---------------------------------------------------------------------------//
+/*!
+ * Programmatic geometry definition: Segmented simple CMS mock up.
+ *
+ * This is a set of single-element concentric cylinders that acts as a
+ * cylindrical cow in a vacuum version of CMS.
+ *
+ * - The World volume is a box, and its dimensions are expressed in cartesian
+ * coordinates [x. y, z].
+ * - **All** other volumes are concentric cylinders, and their dimensions are
+ * expressed as [inner radius, outer radius, length]
+ *
+ * | Volume                       | Composition      | Dimensions [cm]    |
+ * | ---------------------------- | ---------------- | ------------------ |
+ * | world                        | H                | [1000, 1000, 2000] |
+ * | vacuum tube                  | H                | [0, 30, 1400]      |
+ * | silicon tracker              | Si or SiO2       | [30, 125, 1400]    |
+ * | electromagnetic calorimeter  | Pb or Pb3O4      | [125, 175, 1400]   |
+ * | hadron calorimeter           | C                | [175, 275, 1400]   |
+ * | superconducting solenoid     | Ti               | [275, 375, 1400]   |
+ * | muon chambers                | Fe               | [375, 700, 1400]   |
+ *
+ * - Different distances between volumes are set so that geometry navigation
+ * can be tested. These values are defined in \c volume_gaps_ . Current
+ * configuration uses:
+ *
+ * | Volume                       | Gap type   |
+ * | ---------------------------- | ---------- |
+ * | world                        | N/A        |
+ * | vacuum tube                  | tolerance  |
+ * | silicon tracker              | tolerance  |
+ * | electromagnetic calorimeter  | overlap    |
+ * | hadron calorimeter           | overlap    |
+ * | superconducting solenoid     | millimeter |
+ * | muon chambers                | N/A        |
+ *
+ */
+G4VPhysicalVolume* SegmentedSimpleCmsDetector::segmented_simple_cms()
+{
+    // Set up material list
+    MaterialList materials = this->build_materials();
+
+    // Size of World volume
+    double const world_size = 20 * m;
+    // Half length of all concentric cylinders (z-axis)
+    double const half_length = 7 * m;
+
+    struct VolumeGap
+    {
+        double overlap{0};
+        double millimeter{1 * mm};
+        double tolerance{1e-9 * mm};
+    } const volume_gaps;
+
+    // World volume
+    G4Box* world_def
+        = new G4Box("world_box", world_size / 2, world_size / 2, world_size);
+
+    auto const world_lv
+        = new G4LogicalVolume(world_def, materials.world, "world");
+
+    auto const world_pv = new G4PVPlacement(0,  // Rotation matrix
+                                            G4ThreeVector(),  // Position
+                                            world_lv,  // Current LV
+                                            "world_pv",  // Name
+                                            nullptr,  // Mother LV
+                                            false,  // Bool operation
+                                            0,  // Copy number
+                                            false);  // Overlap check
+
+    //// Set up mother tubes needed for the material segments
+
+    // Vacuum tube
+    G4Tubs* vacuum_tube_def = new G4Tubs("lhc_vacuum_tube",
+                                         0,  // Inner radius
+                                         30 * cm,  // Outer radius
+                                         half_length,  // Half-length z
+                                         0 * deg,  // Start angle
+                                         360 * deg);  // Spanning angle
+
+    auto const vacuum_tube_lv = new G4LogicalVolume(
+        vacuum_tube_def, materials.vacuum_tube, "vacuum_tube");
+
+    new G4PVPlacement(0,
+                      G4ThreeVector(),  // Spans -z/2 to +z/2
+                      vacuum_tube_lv,
+                      "vacuum_tube_pv",
+                      world_lv,
+                      false,
+                      0,
+                      false);
+
+    // Si tracker
+    G4Tubs* si_tracker_def = new G4Tubs(
+        "silicon_tracker", 30 * cm, 125 * cm, half_length, 0 * deg, 360 * deg);
+
+    auto const si_tracker_lv
+        = new G4LogicalVolume(si_tracker_def, materials.world, "si_tracker");
+
+    auto si_tracker_pv = new G4PVPlacement(0,
+                                           G4ThreeVector(),
+                                           si_tracker_lv,
+                                           "si_tracker_pv",
+                                           world_lv,
+                                           false,
+                                           0,
+                                           false);
+    // EM calorimeter
+    G4Tubs* em_calorimeter_def = new G4Tubs("crystal_em_calorimeter",
+                                            125 * cm,
+                                            175 * cm - volume_gaps.overlap,
+                                            half_length,
+                                            0 * deg,
+                                            360 * deg);
+
+    auto const em_calorimeter_lv = new G4LogicalVolume(
+        em_calorimeter_def, materials.world, "em_calorimeter");
+
+    new G4PVPlacement(0,
+                      G4ThreeVector(),
+                      em_calorimeter_lv,
+                      "em_calorimeter_pv",
+                      world_lv,
+                      false,
+                      0,
+                      false);
+
+    // Hadron calorimeter
+    G4Tubs* had_calorimeter_def = new G4Tubs("hadron_calorimeter",
+                                             175 * cm,
+                                             275 * cm - volume_gaps.overlap,
+                                             half_length,
+                                             0 * deg,
+                                             360 * deg);
+
+    auto const had_calorimeter_lv = new G4LogicalVolume(
+        had_calorimeter_def, materials.world, "had_calorimeter");
+
+    new G4PVPlacement(0,
+                      G4ThreeVector(),
+                      had_calorimeter_lv,
+                      "had_calorimeter_pv",
+                      world_lv,
+                      false,
+                      0,
+                      false);
+
+    // Superconducting solenoid
+    G4Tubs* sc_solenoid_def = new G4Tubs("superconducting_solenoid",
+                                         275 * cm,
+                                         375 * cm - volume_gaps.millimeter,
+                                         half_length,
+                                         0 * deg,
+                                         360 * deg);
+
+    auto const sc_solenoid_lv
+        = new G4LogicalVolume(sc_solenoid_def, materials.world, "sc_solenoid");
+
+    new G4PVPlacement(0,
+                      G4ThreeVector(),
+                      sc_solenoid_lv,
+                      "sc_solenoid_pv",
+                      world_lv,
+                      false,
+                      0,
+                      false);
+
+    // Muon chambers
+    G4Tubs* muon_chambers_def = new G4Tubs("iron_muon_chambers",
+                                           375 * cm,
+                                           700 * cm,
+                                           half_length,
+                                           0 * deg,
+                                           360 * deg);
+
+    auto const muon_chambers_lv = new G4LogicalVolume(
+        muon_chambers_def, materials.world, "muon_chambers_lv");
+
+    new G4PVPlacement(0,
+                      G4ThreeVector(),
+                      muon_chambers_lv,
+                      "muon_chambers_pv",
+                      world_lv,
+                      false,
+                      0,
+                      false);
+
+    //// Segmented elements
+    double const segment_theta = 2 * CLHEP::pi / num_segments_.num_theta;
+
+    // Si tracker segments
+    G4Tubs* si_tracker_segment_def = new G4Tubs("silicon_tracker_segment",
+                                                30 * cm,
+                                                125 * cm,
+                                                half_length,
+                                                -segment_theta / 2,
+                                                segment_theta / 2);
+
+    auto const si_tracker_segment_lv = new G4LogicalVolume(
+        si_tracker_def, materials.world, "si_tracker_segment");
+
+    new G4PVReplica("si_tracker_segmented_pv",
+                    si_tracker_segment_lv,
+                    si_tracker_lv,
+                    EAxis::kPhi,
+                    num_segments_.num_theta,
+                    segment_theta);
+
+    double const si_segment_r = (125 * cm - 30 * cm) / num_segments_.num_r;
+
+    G4Tubs* si_tracker_segment_def_r = new G4Tubs("silicon_tracker_segment_r",
+                                                  30 * cm,
+                                                  30 * cm + si_segment_r,
+                                                  half_length,
+                                                  -segment_theta / 2,
+                                                  segment_theta / 2);
+
+    auto const si_tracker_segment_r_lv = new G4LogicalVolume(
+        si_tracker_segment_def, materials.si_tracker, "si_tracker_segment_r");
+
+    new G4PVReplica("si_tracker_segmented_r_pv",
+                    si_tracker_segment_r_lv,
+                    si_tracker_segment_lv,
+                    EAxis::kRho,
+                    num_segments_.num_r,
+                    segment_theta);
+
+    // EM calorimeter segments
+    G4Tubs* em_calo_segment_def = new G4Tubs("em_calorimeter_segment",
+                                             125 * cm,
+                                             175 * cm,
+                                             half_length,
+                                             -segment_theta / 2,
+                                             segment_theta / 2);
+
+    auto const em_calo_segment_lv = new G4LogicalVolume(
+        em_calorimeter_def, materials.em_calorimeter, "em_calo_segment_lv");
+
+    new G4PVReplica("em_calo_segmented_pv",
+                    em_calo_segment_lv,
+                    em_calorimeter_lv,
+                    EAxis::kPhi,
+                    num_segments_.num_theta,
+                    segment_theta);
+
+    // Hadron calorimeter segments
+    G4Tubs* had_calo_segment_def = new G4Tubs("had_calorimeter_segment",
+                                              175 * cm,
+                                              275 * cm,
+                                              half_length,
+                                              -segment_theta / 2,
+                                              segment_theta / 2);
+
+    auto const had_calo_segment_lv = new G4LogicalVolume(
+        had_calorimeter_def, materials.had_calorimeter, "had_calo_segment_lv");
+
+    new G4PVReplica("had_calo_segmented_pv",
+                    had_calo_segment_lv,
+                    had_calorimeter_lv,
+                    EAxis::kPhi,
+                    num_segments_.num_theta,
+                    segment_theta);
+
+    // SC solenoid
+    G4Tubs* sc_solenoid_segment_def = new G4Tubs("sc_solenoid_segment",
+                                                 275 * cm,
+                                                 375 * cm,
+                                                 half_length,
+                                                 -segment_theta / 2,
+                                                 segment_theta / 2);
+
+    auto const sc_solenoid_segment_lv = new G4LogicalVolume(
+        sc_solenoid_def, materials.sc_solenoid, "sc_solenoid_segment_lv");
+
+    new G4PVReplica("sc_solenoid_segmented_pv",
+                    sc_solenoid_segment_lv,
+                    sc_solenoid_lv,
+                    EAxis::kPhi,
+                    num_segments_.num_theta,
+                    segment_theta);
+
+    // Muon chambers
+    G4Tubs* muon_chambers_segment_def = new G4Tubs("muon_chambers_segment",
+                                                   375 * cm,
+                                                   700 * cm,
+                                                   half_length,
+                                                   -segment_theta / 2,
+                                                   segment_theta / 2);
+
+    auto const muon_chambers_segment_lv = new G4LogicalVolume(
+        muon_chambers_def, materials.muon_chambers, "muon_chambers_segment_lv");
+
+    new G4PVReplica("muon_chambers_segmented_pv",
+                    muon_chambers_segment_lv,
+                    muon_chambers_lv,
+                    EAxis::kPhi,
+                    num_segments_.num_theta,
+                    segment_theta);
+
+    return world_pv;
+}
+
+//---------------------------------------------------------------------------//
+/*!
+ * TODO
+ */
+void SegmentedSimpleCmsDetector::set_sd()
+{
+    // TODO
+}

--- a/gdml-generator/src/SegmentedSimpleCmsDetector.cc
+++ b/gdml-generator/src/SegmentedSimpleCmsDetector.cc
@@ -310,148 +310,41 @@ G4VPhysicalVolume* SegmentedSimpleCmsDetector::segmented_simple_cms()
                       0,
                       false);
 
-    // - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -//
-    //// Segmented elements
+    // Add segmented elements
+    this->create_segments("si_tracker",
+                          radius.vacuum_tube,
+                          radius.si_tracker,
+                          si_tracker_def,
+                          si_tracker_lv,
+                          materials_.si_tracker);
 
-    double const segment_theta = 2 * CLHEP::pi / num_segments_.num_theta;
+    this->create_segments("em_calorimeter",
+                          radius.si_tracker,
+                          radius.em_calo,
+                          em_calorimeter_def,
+                          em_calorimeter_lv,
+                          materials_.em_calorimeter);
 
-    // Si tracker segments
-    G4Tubs* si_tracker_segment_theta_def
-        = new G4Tubs("si_tracker_segment_theta",
-                     radius.vacuum_tube,
-                     radius.si_tracker,
-                     half_length_,
-                     0,
-                     segment_theta);
+    this->create_segments("had_calorimeter",
+                          radius.em_calo,
+                          radius.had_calo,
+                          had_calorimeter_def,
+                          had_calorimeter_lv,
+                          materials_.had_calorimeter);
 
-    auto const si_tracker_segment_theta_lv = new G4LogicalVolume(
-        si_tracker_def, materials_.world, "si_tracker_segment_theta_lv");
+    this->create_segments("sc_solenoid",
+                          radius.had_calo,
+                          radius.sc_solenoid,
+                          sc_solenoid_def,
+                          sc_solenoid_lv,
+                          materials_.sc_solenoid);
 
-    // - - - - - -
-
-    double const si_segment_r = (radius.si_tracker - radius.vacuum_tube)
-                                / num_segments_.num_r;
-
-    G4Tubs* si_tracker_segment_r_def
-        = new G4Tubs("si_tracker_segment_r_def",
-                     radius.vacuum_tube,
-                     radius.vacuum_tube + si_segment_r,
-                     half_length_,
-                     0,
-                     segment_theta);
-
-    auto const si_tracker_segment_r_lv = new G4LogicalVolume(
-        si_tracker_segment_r_def, materials_.world, "si_tracker_segment_r_lv");
-
-    new G4PVReplica("si_tracker_segment_r_pv",
-                    si_tracker_segment_r_lv,
-                    si_tracker_segment_theta_lv,
-                    EAxis::kRho,
-                    (G4int)num_segments_.num_r,
-                    0);
-
-    new G4PVReplica("si_tracker_segment_theta_pv",
-                    si_tracker_segment_theta_lv,
-                    si_tracker_lv,
-                    EAxis::kPhi,
-                    num_segments_.num_theta,
-                    segment_theta);
-
-    double const si_segment_z = 2 * half_length_ / num_segments_.num_z;
-
-    G4Tubs* si_tracker_segment_z_def
-        = new G4Tubs("si_tracker_segment_z_def",
-                     radius.vacuum_tube,
-                     radius.vacuum_tube + si_segment_r,
-                     si_segment_z / 2,
-                     0,
-                     segment_theta);
-
-    auto const si_tracker_segment_z_lv
-        = new G4LogicalVolume(si_tracker_segment_z_def,
-                              materials_.si_tracker,
-                              "si_tracker_segment_z_lv");
-
-    new G4PVDivision("si_tracker_segment_z_pv",
-                     si_tracker_segment_z_lv,
-                     si_tracker_segment_r_lv,
-                     EAxis::kZAxis,
-                     (G4int)num_segments_.num_z,
-                     0);
-
-#if 0
-    // EM calorimeter segments
-    G4Tubs* em_calo_segment_def = new G4Tubs("em_calorimeter_segment",
-                                             125 * cm,
-                                             175 * cm,
-                                             half_length_,
-                                             0,
-                                             segment_theta);
-
-    auto const em_calo_segment_lv = new G4LogicalVolume(
-        em_calorimeter_def, materials_.em_calorimeter, "em_calo_segment_lv");
-
-    new G4PVReplica("em_calo_segmented_pv",
-                    em_calo_segment_lv,
-                    em_calorimeter_lv,
-                    EAxis::kPhi,
-                    num_segments_.num_theta,
-                    segment_theta);
-
-    // Hadron calorimeter segments
-    G4Tubs* had_calo_segment_def = new G4Tubs("had_calorimeter_segment",
-                                              175 * cm,
-                                              275 * cm,
-                                              half_length_,
-                                              0,
-                                              segment_theta );
-
-    auto const had_calo_segment_lv = new G4LogicalVolume(
-        had_calorimeter_def, materials_.had_calorimeter, "had_calo_segment_lv");
-
-    new G4PVReplica("had_calo_segmented_pv",
-                    had_calo_segment_lv,
-                    had_calorimeter_lv,
-                    EAxis::kPhi,
-                    num_segments_.num_theta,
-                    segment_theta);
-
-    // SC solenoid
-    G4Tubs* sc_solenoid_segment_def = new G4Tubs("sc_solenoid_segment",
-                                                 275 * cm,
-                                                 375 * cm,
-                                                 half_length_,
-                                                 0,
-                                                 segment_theta );
-
-    auto const sc_solenoid_segment_lv = new G4LogicalVolume(
-        sc_solenoid_def, materials_.sc_solenoid, "sc_solenoid_segment_lv");
-
-    new G4PVReplica("sc_solenoid_segmented_pv",
-                    sc_solenoid_segment_lv,
-                    sc_solenoid_lv,
-                    EAxis::kPhi,
-                    num_segments_.num_theta,
-                    segment_theta);
-
-    // Muon chambers
-    G4Tubs* muon_chambers_segment_def = new G4Tubs("muon_chambers_segment",
-                                                   375 * cm,
-                                                   700 * cm,
-                                                   half_length_,
-                                                   0,
-                                                   segment_theta);
-
-    auto const muon_chambers_segment_lv = new G4LogicalVolume(
-        muon_chambers_def, materials_.muon_chambers, "muon_chambers_segment_lv");
-
-    new G4PVReplica("muon_chambers_segmented_pv",
-                    muon_chambers_segment_lv,
-                    muon_chambers_lv,
-                    EAxis::kPhi,
-                    num_segments_.num_theta,
-                    segment_theta);
-#endif
+    this->create_segments("muon_chambers",
+                          radius.sc_solenoid,
+                          radius.muon_chambers,
+                          muon_chambers_def,
+                          muon_chambers_lv,
+                          materials_.muon_chambers);
 
     return world_pv;
 }
@@ -467,7 +360,7 @@ void SegmentedSimpleCmsDetector::set_sd()
 
 //---------------------------------------------------------------------------//
 /*!
- * TODO
+ * Generate segments in r, theta, and z for a given cylinder.
  */
 void SegmentedSimpleCmsDetector::create_segments(
     std::string name,
@@ -509,7 +402,7 @@ void SegmentedSimpleCmsDetector::create_segments(
                     segment_r_lv,
                     segment_theta_lv,
                     EAxis::kRho,
-                    (G4int)num_segments_.num_r,
+                    num_segments_.num_r,
                     0);
 
     std::string name_theta_pv = name_theta + "_pv";
@@ -540,6 +433,6 @@ void SegmentedSimpleCmsDetector::create_segments(
                      si_tracker_segment_z_lv,
                      segment_r_lv,
                      EAxis::kZAxis,
-                     (G4int)num_segments_.num_z,
+                     num_segments_.num_z,
                      0);
 }

--- a/gdml-generator/src/SegmentedSimpleCmsDetector.hh
+++ b/gdml-generator/src/SegmentedSimpleCmsDetector.hh
@@ -1,0 +1,92 @@
+//----------------------------------*-C++-*----------------------------------//
+// Copyright 2023 UT-Battelle, LLC, and other Celeritas developers.
+// See the top-level COPYRIGHT file for details.
+// SPDX-License-Identifier: (Apache-2.0 OR MIT)
+//---------------------------------------------------------------------------//
+//! \file SegmentedSimpleCmsDetector.hh
+//! \brief Create the detector geometry.
+//---------------------------------------------------------------------------//
+#pragma once
+
+#include <string>
+#include <G4Material.hh>
+#include <G4SystemOfUnits.hh>
+#include <G4VPhysicalVolume.hh>
+#include <G4VUserDetectorConstruction.hh>
+
+//---------------------------------------------------------------------------//
+/*!
+ * Construct a programmatic detector geometry.
+ */
+class SegmentedSimpleCmsDetector : public G4VUserDetectorConstruction
+{
+  public:
+    enum class MaterialType
+    {
+        simple,
+        composite
+    };
+
+    struct SegmentDefinition
+    {
+        std::size_t num_theta;
+        std::size_t num_r;
+        std::size_t num_z;
+    };
+
+    // Construct with geometry type
+    SegmentedSimpleCmsDetector(MaterialType type, SegmentDefinition segments);
+
+    // Construct geometry
+    G4VPhysicalVolume* Construct() final;
+    // Set up sensitive detectors and magnetic field
+    void ConstructSDandField() final;
+
+  private:
+    // Material selection
+    struct MaterialList
+    {
+        G4Material* world;
+        G4Material* vacuum_tube;
+        G4Material* si_tracker;
+        G4Material* em_calorimeter;
+        G4Material* had_calorimeter;
+        G4Material* sc_solenoid;
+        G4Material* muon_chambers;
+    };
+
+#if 0
+    // Volume sizes
+    struct VolumeSize
+    {
+        double half_z_len = 7 * m;
+        double vacuum_tube_r = 30 * cm;
+        double si_tracker_r = 125 * cm - vacuum_tube_r;
+        double em_calorimeter_r = 175 * cm - si_tracker_r;
+        double had_calorimeter_r = 275 * cm - em_calorimeter_r;
+        double sc_solenoid_r = 375 * cm - em_calorimeter_r;
+        double mu_chambers_r = 700 * cm - em_calorimeter_r;
+    } const static volume_size_;
+
+    struct VolumeRadiusLimit
+    {
+        double vacuum_tube[2] = {0, volume_size_.vacuum_tube_r};
+        double s_tracker[2]
+            = {vacuum_tube[1], vacuum_tube[1] + volume_size_.si_tracker_r};
+    } const static volume_r_lim_;
+#endif
+
+    // Select simple/composite geometry
+    MaterialType geometry_type_;
+
+    // Number of segments
+    SegmentDefinition num_segments_;
+
+  private:
+    // Segmented simple CMS
+    G4VPhysicalVolume* segmented_simple_cms();
+    // Set sensitive detectors
+    void set_sd();
+    // Build material list based on MaterialType
+    MaterialList build_materials();
+};

--- a/gdml-generator/src/SegmentedSimpleCmsDetector.hh
+++ b/gdml-generator/src/SegmentedSimpleCmsDetector.hh
@@ -11,6 +11,7 @@
 #include <string>
 #include <G4Material.hh>
 #include <G4SystemOfUnits.hh>
+#include <G4Tubs.hh>
 #include <G4VPhysicalVolume.hh>
 #include <G4VUserDetectorConstruction.hh>
 
@@ -53,28 +54,10 @@ class SegmentedSimpleCmsDetector : public G4VUserDetectorConstruction
         G4Material* had_calorimeter;
         G4Material* sc_solenoid;
         G4Material* muon_chambers;
-    };
+    } materials_;
 
-#if 0
-    // Volume sizes
-    struct VolumeSize
-    {
-        double half_z_len = 7 * m;
-        double vacuum_tube_r = 30 * cm;
-        double si_tracker_r = 125 * cm - vacuum_tube_r;
-        double em_calorimeter_r = 175 * cm - si_tracker_r;
-        double had_calorimeter_r = 275 * cm - em_calorimeter_r;
-        double sc_solenoid_r = 375 * cm - em_calorimeter_r;
-        double mu_chambers_r = 700 * cm - em_calorimeter_r;
-    } const static volume_size_;
-
-    struct VolumeRadiusLimit
-    {
-        double vacuum_tube[2] = {0, volume_size_.vacuum_tube_r};
-        double s_tracker[2]
-            = {vacuum_tube[1], vacuum_tube[1] + volume_size_.si_tracker_r};
-    } const static volume_r_lim_;
-#endif
+    // Cylinder half length
+    double const half_length_{7 * m};
 
     // Select simple/composite geometry
     MaterialType geometry_type_;
@@ -85,8 +68,18 @@ class SegmentedSimpleCmsDetector : public G4VUserDetectorConstruction
   private:
     // Segmented simple CMS
     G4VPhysicalVolume* segmented_simple_cms();
+
     // Set sensitive detectors
     void set_sd();
+
     // Build material list based on MaterialType
     MaterialList build_materials();
+
+    // Construct segments for each main cylinder
+    void create_segments(std::string name,
+                         double inner_r,
+                         double outer_r,
+                         G4Tubs* full_culinder_def,
+                         G4LogicalVolume* full_cylinder_lv,
+                         G4Material* cyl_material);
 };

--- a/gdml-generator/src/SegmentedSimpleCmsDetector.hh
+++ b/gdml-generator/src/SegmentedSimpleCmsDetector.hh
@@ -35,7 +35,7 @@ class SegmentedSimpleCmsDetector : public G4VUserDetectorConstruction
         int num_z;
     };
 
-    // Construct with geometry type
+    // Construct with geometry type and number of segments
     SegmentedSimpleCmsDetector(MaterialType type, SegmentDefinition segments);
 
     // Construct geometry

--- a/gdml-generator/src/SegmentedSimpleCmsDetector.hh
+++ b/gdml-generator/src/SegmentedSimpleCmsDetector.hh
@@ -83,4 +83,12 @@ class SegmentedSimpleCmsDetector : public G4VUserDetectorConstruction
                          G4Tubs* full_culinder_def,
                          G4LogicalVolume* full_cylinder_lv,
                          G4Material* cyl_material);
+
+    // Build segments manually by just placing volumes
+    G4VPhysicalVolume* flat_segmented_simple_cms();
+    void flat_segmented_cylinder(std::string name,
+                                 double inner_r,
+                                 double outer_r,
+                                 G4Material* material,
+                                 G4VPhysicalVolume* world_pv);
 };

--- a/gdml-generator/src/SegmentedSimpleCmsDetector.hh
+++ b/gdml-generator/src/SegmentedSimpleCmsDetector.hh
@@ -30,9 +30,9 @@ class SegmentedSimpleCmsDetector : public G4VUserDetectorConstruction
 
     struct SegmentDefinition
     {
-        std::size_t num_theta;
-        std::size_t num_r;
-        std::size_t num_z;
+        int num_theta;
+        int num_r;
+        int num_z;
     };
 
     // Construct with geometry type
@@ -40,6 +40,7 @@ class SegmentedSimpleCmsDetector : public G4VUserDetectorConstruction
 
     // Construct geometry
     G4VPhysicalVolume* Construct() final;
+
     // Set up sensitive detectors and magnetic field
     void ConstructSDandField() final;
 

--- a/gdml-generator/src/SegmentedSimpleCmsDetector.hh
+++ b/gdml-generator/src/SegmentedSimpleCmsDetector.hh
@@ -57,6 +57,20 @@ class SegmentedSimpleCmsDetector : public G4VUserDetectorConstruction
         G4Material* muon_chambers;
     } materials_;
 
+    // Size of World volume
+    double const world_size_ = 20 * m;
+
+    // Hardcoded cylinder sizes
+    struct CylinderRadius
+    {
+        double vacuum_tube{30 * cm};
+        double si_tracker{125 * cm};
+        double em_calo{175 * cm};
+        double had_calo{275 * cm};
+        double sc_solenoid{375 * cm};
+        double muon_chambers{700 * cm};
+    } const radius_;
+
     // Cylinder half length
     double const half_length_{7 * m};
 
@@ -66,8 +80,11 @@ class SegmentedSimpleCmsDetector : public G4VUserDetectorConstruction
     // Number of segments
     SegmentDefinition num_segments_;
 
+    // Use flat geometry construction
+    bool const flat_segmentation{true};
+
   private:
-    // Segmented simple CMS
+    // Segmented simple CMS using replicas and divisions
     G4VPhysicalVolume* segmented_simple_cms();
 
     // Set sensitive detectors
@@ -76,7 +93,7 @@ class SegmentedSimpleCmsDetector : public G4VUserDetectorConstruction
     // Build material list based on MaterialType
     MaterialList build_materials();
 
-    // Construct segments for each main cylinder
+    // Construct segments for each main cylinder using replicas and divisions
     void create_segments(std::string name,
                          double inner_r,
                          double outer_r,
@@ -84,8 +101,10 @@ class SegmentedSimpleCmsDetector : public G4VUserDetectorConstruction
                          G4LogicalVolume* full_cylinder_lv,
                          G4Material* cyl_material);
 
-    // Build segments manually by just placing volumes
+    // Segmented simple CMS with manually placed volumes
     G4VPhysicalVolume* flat_segmented_simple_cms();
+
+    // Construct a segmented cylinder by manually placing smaller ones
     void flat_segmented_cylinder(std::string name,
                                  double inner_r,
                                  double outer_r,

--- a/gdml-generator/src/SimpleCMSDetector.cc
+++ b/gdml-generator/src/SimpleCMSDetector.cc
@@ -3,9 +3,9 @@
 // See the top-level COPYRIGHT file for details.
 // SPDX-License-Identifier: (Apache-2.0 OR MIT)
 //---------------------------------------------------------------------------//
-//! \file SimpleCMSDetector.cc
+//! \file SimpleCmsDetector.cc
 //---------------------------------------------------------------------------//
-#include "SimpleCMSDetector.hh"
+#include "SimpleCmsDetector.hh"
 
 #include <G4Box.hh>
 #include <G4Colour.hh>
@@ -22,7 +22,7 @@
 /*!
  * Construct with geometry type enum.
  */
-SimpleCMSDetector::SimpleCMSDetector(MaterialType type) : geometry_type_(type)
+SimpleCmsDetector::SimpleCmsDetector(MaterialType type) : geometry_type_(type)
 {
 }
 
@@ -30,7 +30,7 @@ SimpleCMSDetector::SimpleCMSDetector(MaterialType type) : geometry_type_(type)
 /*!
  * Mandatory Construct function.
  */
-G4VPhysicalVolume* SimpleCMSDetector::Construct()
+G4VPhysicalVolume* SimpleCmsDetector::Construct()
 {
     return this->simple_cms();
 }
@@ -39,7 +39,7 @@ G4VPhysicalVolume* SimpleCMSDetector::Construct()
 /*!
  * Set sensitive detectors and (TODO) magnetic field.
  */
-void SimpleCMSDetector::ConstructSDandField()
+void SimpleCmsDetector::ConstructSDandField()
 {
     this->set_sd();
 
@@ -54,7 +54,7 @@ void SimpleCMSDetector::ConstructSDandField()
 /*!
  * Define list of materials.
  */
-SimpleCMSDetector::MaterialList SimpleCMSDetector::build_materials()
+SimpleCmsDetector::MaterialList SimpleCmsDetector::build_materials()
 {
     MaterialList materials;
     G4NistManager* nist = G4NistManager::Instance();
@@ -147,7 +147,7 @@ SimpleCMSDetector::MaterialList SimpleCMSDetector::build_materials()
  * | muon chambers                | N/A        |
  *
  */
-G4VPhysicalVolume* SimpleCMSDetector::simple_cms()
+G4VPhysicalVolume* SimpleCmsDetector::simple_cms()
 {
     // Set up material list
     MaterialList materials = this->build_materials();
@@ -299,7 +299,7 @@ G4VPhysicalVolume* SimpleCMSDetector::simple_cms()
  * The two first inner cylinders, which represent the silicon tracker and the
  * EM calorimeter, are used as sensitive scoring regions.
  */
-void SimpleCMSDetector::set_sd()
+void SimpleCmsDetector::set_sd()
 {
     // List of sensitive detectors
     auto si_tracker_sd = new SensitiveDetector("si_tracker_sd");

--- a/gdml-generator/src/SimpleCMSDetector.cc
+++ b/gdml-generator/src/SimpleCMSDetector.cc
@@ -7,14 +7,14 @@
 //---------------------------------------------------------------------------//
 #include "SimpleCMSDetector.hh"
 
-#include <G4NistManager.hh>
 #include <G4Box.hh>
-#include <G4Tubs.hh>
-#include <G4LogicalVolume.hh>
-#include <G4PVPlacement.hh>
-#include <G4VisAttributes.hh>
 #include <G4Colour.hh>
+#include <G4LogicalVolume.hh>
+#include <G4NistManager.hh>
+#include <G4PVPlacement.hh>
 #include <G4SDManager.hh>
+#include <G4Tubs.hh>
+#include <G4VisAttributes.hh>
 
 #include "core/SensitiveDetector.hh"
 
@@ -56,20 +56,20 @@ void SimpleCMSDetector::ConstructSDandField()
  */
 SimpleCMSDetector::MaterialList SimpleCMSDetector::build_materials()
 {
-    MaterialList   materials;
+    MaterialList materials;
     G4NistManager* nist = G4NistManager::Instance();
 
     switch (geometry_type_)
     {
         case MaterialType::simple:
             // Load materials
-            materials.world       = nist->FindOrBuildMaterial("G4_Galactic");
+            materials.world = nist->FindOrBuildMaterial("G4_Galactic");
             materials.vacuum_tube = nist->FindOrBuildMaterial("G4_Galactic");
-            materials.si_tracker  = nist->FindOrBuildMaterial("G4_Si");
-            materials.em_calorimeter  = nist->FindOrBuildMaterial("G4_Pb");
+            materials.si_tracker = nist->FindOrBuildMaterial("G4_Si");
+            materials.em_calorimeter = nist->FindOrBuildMaterial("G4_Pb");
             materials.had_calorimeter = nist->FindOrBuildMaterial("G4_C");
-            materials.sc_solenoid     = nist->FindOrBuildMaterial("G4_Ti");
-            materials.muon_chambers   = nist->FindOrBuildMaterial("G4_Fe");
+            materials.sc_solenoid = nist->FindOrBuildMaterial("G4_Ti");
+            materials.muon_chambers = nist->FindOrBuildMaterial("G4_Fe");
 
             // Update names
             materials.world->SetName("vacuum");
@@ -83,15 +83,15 @@ SimpleCMSDetector::MaterialList SimpleCMSDetector::build_materials()
 
         case MaterialType::composite:
             // Load materials
-            materials.world       = nist->FindOrBuildMaterial("G4_Galactic");
+            materials.world = nist->FindOrBuildMaterial("G4_Galactic");
             materials.vacuum_tube = nist->FindOrBuildMaterial("G4_Galactic");
             materials.si_tracker
                 = nist->FindOrBuildMaterial("G4_SILICON_DIOXIDE");
             materials.em_calorimeter
                 = nist->FindOrBuildMaterial("G4_LEAD_OXIDE");
             materials.had_calorimeter = nist->FindOrBuildMaterial("G4_C");
-            materials.sc_solenoid     = nist->FindOrBuildMaterial("G4_Ti");
-            materials.muon_chambers   = nist->FindOrBuildMaterial("G4_Fe");
+            materials.sc_solenoid = nist->FindOrBuildMaterial("G4_Ti");
+            materials.muon_chambers = nist->FindOrBuildMaterial("G4_Fe");
 
             // Update names
             materials.world->SetName("vacuum");
@@ -114,7 +114,7 @@ SimpleCMSDetector::MaterialList SimpleCMSDetector::build_materials()
 /*!
  * Programmatic geometry definition: Single material CMS mock up.
  *
- * This is a set of single-element concentric cylinders that acts as a
+ * This is a set of single-material concentric cylinders that acts as a
  * cylindrical cow in a vacuum version of CMS.
  *
  * - The World volume is a box, and its dimensions are expressed in cartesian
@@ -153,9 +153,9 @@ G4VPhysicalVolume* SimpleCMSDetector::simple_cms()
     MaterialList materials = this->build_materials();
 
     // Size of World volume
-    const double world_size = 20 * m;
+    double const world_size = 20 * m;
     // Half length of all concentric cylinders (z-axis)
-    const double half_length = 7 * m;
+    double const half_length = 7 * m;
 
     // List of solids
     G4Box* world_def
@@ -163,11 +163,11 @@ G4VPhysicalVolume* SimpleCMSDetector::simple_cms()
 
     G4Tubs* vacuum_tube_def
         = new G4Tubs("lhc_vacuum_tube",
-                     0,                                // Inner radius
-                     30 * cm - volume_gaps_.tolerance, // Outer radius
-                     half_length,                      // Half-length z
-                     0 * deg,                          // Start angle
-                     360 * deg);                       // Spanning angle
+                     0,  // Inner radius
+                     30 * cm - volume_gaps_.tolerance,  // Outer radius
+                     half_length,  // Half-length z
+                     0 * deg,  // Start angle
+                     360 * deg);  // Spanning angle
 
     G4Tubs* si_tracker_def = new G4Tubs("silicon_tracker",
                                         30 * cm,
@@ -205,36 +205,36 @@ G4VPhysicalVolume* SimpleCMSDetector::simple_cms()
                                                 360 * deg);
 
     // List of logical volumes
-    const auto world_lv
+    auto const world_lv
         = new G4LogicalVolume(world_def, materials.world, "world");
 
-    const auto vacuum_tube_lv = new G4LogicalVolume(
+    auto const vacuum_tube_lv = new G4LogicalVolume(
         vacuum_tube_def, materials.vacuum_tube, "vacuum_tube");
 
-    const auto si_tracker_lv = new G4LogicalVolume(
+    auto const si_tracker_lv = new G4LogicalVolume(
         si_tracker_def, materials.si_tracker, "si_tracker");
 
-    const auto em_calorimeter_lv = new G4LogicalVolume(
+    auto const em_calorimeter_lv = new G4LogicalVolume(
         em_calorimeter_def, materials.em_calorimeter, "em_calorimeter");
 
-    const auto had_calorimeter_lv = new G4LogicalVolume(
+    auto const had_calorimeter_lv = new G4LogicalVolume(
         had_calorimeter_def, materials.had_calorimeter, "had_calorimeter");
 
-    const auto sc_solenoid_lv = new G4LogicalVolume(
+    auto const sc_solenoid_lv = new G4LogicalVolume(
         sc_solenoid_def, materials.sc_solenoid, "sc_solenoid");
 
-    const auto iron_muon_chambers_lv = new G4LogicalVolume(
+    auto const iron_muon_chambers_lv = new G4LogicalVolume(
         iron_muon_chambers_def, materials.muon_chambers, "fe_muon_chambers");
 
     // List of physical volumes
-    const auto world_pv = new G4PVPlacement(0,               // Rotation matrix
-                                            G4ThreeVector(), // Position
-                                            world_lv,        // Current LV
-                                            "world_pv",      // Name
-                                            nullptr,         // Mother LV
-                                            false,           // Bool operation
-                                            0,               // Copy number
-                                            false);          // Overlap check
+    auto const world_pv = new G4PVPlacement(0,  // Rotation matrix
+                                            G4ThreeVector(),  // Position
+                                            world_lv,  // Current LV
+                                            "world_pv",  // Name
+                                            nullptr,  // Mother LV
+                                            false,  // Bool operation
+                                            0,  // Copy number
+                                            false);  // Overlap check
 
     new G4PVPlacement(0,
                       G4ThreeVector(),
@@ -302,7 +302,7 @@ G4VPhysicalVolume* SimpleCMSDetector::simple_cms()
 void SimpleCMSDetector::set_sd()
 {
     // List of sensitive detectors
-    auto si_tracker_sd     = new SensitiveDetector("si_tracker_sd");
+    auto si_tracker_sd = new SensitiveDetector("si_tracker_sd");
     auto em_calorimeter_sd = new SensitiveDetector("em_calorimeter_sd");
 
     // Add SD to manager

--- a/gdml-generator/src/SimpleCMSDetector.hh
+++ b/gdml-generator/src/SimpleCMSDetector.hh
@@ -3,22 +3,22 @@
 // See the top-level COPYRIGHT file for details.
 // SPDX-License-Identifier: (Apache-2.0 OR MIT)
 //---------------------------------------------------------------------------//
-//! \file SimpleCMSDetector.hh
+//! \file SimpleCmsDetector.hh
 //! \brief Create the detector geometry.
 //---------------------------------------------------------------------------//
 #pragma once
 
 #include <string>
-#include <G4VUserDetectorConstruction.hh>
 #include <G4Material.hh>
-#include <G4VPhysicalVolume.hh>
 #include <G4SystemOfUnits.hh>
+#include <G4VPhysicalVolume.hh>
+#include <G4VUserDetectorConstruction.hh>
 
 //---------------------------------------------------------------------------//
 /*!
  * Construct a programmatic detector geometry.
  */
-class SimpleCMSDetector : public G4VUserDetectorConstruction
+class SimpleCmsDetector : public G4VUserDetectorConstruction
 {
   public:
     enum class MaterialType
@@ -28,7 +28,7 @@ class SimpleCMSDetector : public G4VUserDetectorConstruction
     };
 
     // Construct with geometry type
-    SimpleCMSDetector(MaterialType type);
+    SimpleCmsDetector(MaterialType type);
 
     // Construct geometry
     G4VPhysicalVolume* Construct() final;


### PR DESCRIPTION
Add option to generate a segmented `simple-cms` geometry by splitting each material cylinder into any number of segments in each direction. This new `SegmentedSimpleCmsDetector` class can construct the segments manually, by simply creating and placing new cylinder sections directly into the world volume, or using `G4PVReplica` + `G4PVDivision`. The latter is not yet compatible with VecGeom.