### PR TITLE
Assign SDs to `four-steel-slabs` geometry and refactor names of detector construction classes

### DIFF
--- a/gdml-generator/CMakeLists.txt
+++ b/gdml-generator/CMakeLists.txt
@@ -24,13 +24,13 @@ find_package(Geant4 REQUIRED gdml)
 add_executable(gdml-gen gdml-gen.cc
   src/core/PhysicsList.cc
   src/core/SensitiveDetector.cc
-  src/BoxDetector.cc
+  src/Box.cc
   src/FourSteelSlabs.cc
-  src/OpticalDetector.cc
-  src/SegmentedSimpleCmsDetector.cc
-  src/SimpleCmsDetector.cc
-  src/TestEm3Detector.cc
-  src/ThinSlabDetector.cc
+  src/OpticalBoxes.cc
+  src/SegmentedSimpleCms.cc
+  src/SimpleCms.cc
+  src/TestEm3.cc
+  src/ThinSlab.cc
   src/SimpleLZ.cc
 )
 

--- a/gdml-generator/gdml-gen.cc
+++ b/gdml-generator/gdml-gen.cc
@@ -23,14 +23,14 @@
 #include <G4UImanager.hh>
 #include <stdlib.h>
 
-#include "BoxDetector.hh"
+#include "Box.hh"
 #include "FourSteelSlabs.hh"
-#include "OpticalDetector.hh"
-#include "SegmentedSimpleCmsDetector.hh"
-#include "SimpleCmsDetector.hh"
+#include "OpticalBoxes.hh"
+#include "SegmentedSimpleCms.hh"
+#include "SimpleCms.hh"
 #include "SimpleLZ.hh"
-#include "TestEm3Detector.hh"
-#include "ThinSlabDetector.hh"
+#include "TestEm3.hh"
+#include "ThinSlab.hh"
 #include "core/PhysicsList.hh"
 
 //---------------------------------------------------------------------------//
@@ -49,7 +49,7 @@ enum class GeometryID
     testem3_composite,  //!< Composite materials
     testem3_flat,  //!< Simple materials, flat (for ORANGE)
     testem3_composite_flat,  //!< Composite materials flat (for ORANGE)
-    optical,  //!< Simple geometry with optical properties
+    optical_boxes,  //!< Boxes with optical properties
     thin_slab,  //!< Single material thin slab for MSC validation
     simple_lz,  //!< Simplified model of the LUX-ZEPLIN detector array
     size_
@@ -96,7 +96,8 @@ constexpr char const* label(GeometryID id) noexcept
             return "TestEm3 flat - composite materials, for ORANGE";
             break;
         case GID::optical:
-            return "Optical - composite materials with optical properties";
+            return "Optical boxes - composite material boxes with optical "
+                   "properties";
             break;
         case GID::thin_slab:
             return "Thin Pb slab";
@@ -141,10 +142,9 @@ void print_help(char const* argv)
 
 //---------------------------------------------------------------------------//
 /*!
- * Set up number of segments for SegmentedSimpleCmsDetector geometry.
+ * Set up number of segments for SegmentedSimpleCms geometry.
  */
-SegmentedSimpleCmsDetector::SegmentDefinition
-get_segments(int argc, char* argv[])
+SegmentedSimpleCms::SegmentDefinition get_segments(int argc, char* argv[])
 {
     if (argc != 5)
     {
@@ -155,7 +155,7 @@ get_segments(int argc, char* argv[])
         exit(EXIT_FAILURE);
     }
 
-    SegmentedSimpleCmsDetector::SegmentDefinition def;
+    SegmentedSimpleCms::SegmentDefinition def;
     def.num_r = std::stoi(argv[2]);
     def.num_z = std::stoi(argv[3]);
     def.num_theta = std::stoi(argv[4]);
@@ -226,17 +226,17 @@ int main(int argc, char* argv[])
         G4RunManagerFactory::CreateRunManager(G4RunManagerType::Serial));
 #endif
 
-    using CMSType = SimpleCmsDetector::MaterialType;
-    using SCMSType = SegmentedSimpleCmsDetector::MaterialType;
-    using TestEm3MatType = TestEm3Detector::MaterialType;
-    using TestEm3GeoType = TestEm3Detector::GeometryType;
+    using CMSType = SimpleCms::MaterialType;
+    using SCMSType = SegmentedSimpleCms::MaterialType;
+    using TestEm3MatType = TestEm3::MaterialType;
+    using TestEm3GeoType = TestEm3::GeometryType;
 
     // Construct geometry and define gdml filename
     std::string gdml_filename;
     switch (geometry_id)
     {
         case GeometryID::box:
-            run_manager->SetUserInitialization(new BoxDetector());
+            run_manager->SetUserInitialization(new Box());
             gdml_filename = "box.gdml";
             break;
 
@@ -246,60 +246,59 @@ int main(int argc, char* argv[])
             break;
 
         case GeometryID::simple_cms:
-            run_manager->SetUserInitialization(
-                new SimpleCmsDetector(CMSType::simple));
+            run_manager->SetUserInitialization(new SimpleCms(CMSType::simple));
             gdml_filename = "simple-cms.gdml";
             break;
 
         case GeometryID::simple_cms_composite:
             run_manager->SetUserInitialization(
-                new SimpleCmsDetector(CMSType::composite));
+                new SimpleCms(CMSType::composite));
             gdml_filename = "composite-simple-cms.gdml";
             break;
 
         case GeometryID::segmented_simple_cms:
-            run_manager->SetUserInitialization(new SegmentedSimpleCmsDetector(
+            run_manager->SetUserInitialization(new SegmentedSimpleCms(
                 SCMSType::simple, get_segments(argc, argv)));
             gdml_filename = "segmented-simple-cms.gdml";
             break;
 
         case GeometryID::segmented_simple_cms_composite:
-            run_manager->SetUserInitialization(new SegmentedSimpleCmsDetector(
+            run_manager->SetUserInitialization(new SegmentedSimpleCms(
                 SCMSType::composite, get_segments(argc, argv)));
             gdml_filename = "composite-segmented-simple-cms.gdml";
             break;
 
         case GeometryID::testem3:
-            run_manager->SetUserInitialization(new TestEm3Detector(
+            run_manager->SetUserInitialization(new TestEm3(
                 TestEm3MatType::simple, TestEm3GeoType::hierarchical));
             gdml_filename = "testem3.gdml";
             break;
 
         case GeometryID::testem3_composite:
-            run_manager->SetUserInitialization(new TestEm3Detector(
+            run_manager->SetUserInitialization(new TestEm3(
                 TestEm3MatType::composite, TestEm3GeoType::hierarchical));
             gdml_filename = "testem3-composite.gdml";
             break;
 
         case GeometryID::testem3_flat:
-            run_manager->SetUserInitialization(new TestEm3Detector(
-                TestEm3MatType::simple, TestEm3GeoType::flat));
+            run_manager->SetUserInitialization(
+                new TestEm3(TestEm3MatType::simple, TestEm3GeoType::flat));
             gdml_filename = "testem3-flat.gdml";
             break;
 
         case GeometryID::testem3_composite_flat:
-            run_manager->SetUserInitialization(new TestEm3Detector(
-                TestEm3MatType::composite, TestEm3GeoType::flat));
+            run_manager->SetUserInitialization(
+                new TestEm3(TestEm3MatType::composite, TestEm3GeoType::flat));
             gdml_filename = "testem3-flat-composite.gdml";
             break;
 
         case GeometryID::optical:
-            run_manager->SetUserInitialization(new OpticalDetector());
+            run_manager->SetUserInitialization(new OpticalBoxes());
             gdml_filename = "optical.gdml";
             break;
 
         case GeometryID::thin_slab:
-            run_manager->SetUserInitialization(new ThinSlabDetector());
+            run_manager->SetUserInitialization(new ThinSlab());
             gdml_filename = "thin-slab.gdml";
             break;
 

--- a/gdml-generator/src/Box.cc
+++ b/gdml-generator/src/Box.cc
@@ -3,19 +3,19 @@
 // See the top-level COPYRIGHT file for details.
 // SPDX-License-Identifier: (Apache-2.0 OR MIT)
 //---------------------------------------------------------------------------//
-//! \file BoxDetector.cc
+//! \file Box.cc
 //---------------------------------------------------------------------------//
-#include "BoxDetector.hh"
+#include "Box.hh"
 
-#include <G4NistManager.hh>
 #include <G4Box.hh>
-#include <G4Tubs.hh>
-#include <G4LogicalVolume.hh>
-#include <G4PVPlacement.hh>
-#include <G4VisAttributes.hh>
 #include <G4Colour.hh>
+#include <G4LogicalVolume.hh>
+#include <G4NistManager.hh>
+#include <G4PVPlacement.hh>
 #include <G4SDManager.hh>
 #include <G4SystemOfUnits.hh>
+#include <G4Tubs.hh>
+#include <G4VisAttributes.hh>
 
 #include "core/SensitiveDetector.hh"
 
@@ -23,13 +23,13 @@
 /*!
  * Construct empty.
  */
-BoxDetector::BoxDetector() {}
+Box::Box() {}
 
 //---------------------------------------------------------------------------//
 /*!
  * Mandatory Construct function.
  */
-G4VPhysicalVolume* BoxDetector::Construct()
+G4VPhysicalVolume* Box::Construct()
 {
     return this->create_box();
 }
@@ -38,7 +38,7 @@ G4VPhysicalVolume* BoxDetector::Construct()
 /*!
  * Set sensitive detectors and (TODO) magnetic field.
  */
-void BoxDetector::ConstructSDandField()
+void Box::ConstructSDandField()
 {
     this->set_sd();
 
@@ -53,10 +53,10 @@ void BoxDetector::ConstructSDandField()
 /*!
  * Programmatic geometry definition: Cube made of Pb with 500 m side.
  */
-G4VPhysicalVolume* BoxDetector::create_box()
+G4VPhysicalVolume* Box::create_box()
 {
     // World material
-    const char* world_material_name = "G4_Pb";
+    char const* world_material_name = "G4_Pb";
     G4Material* world_material
         = G4NistManager::Instance()->FindOrBuildMaterial(world_material_name);
 
@@ -64,25 +64,25 @@ G4VPhysicalVolume* BoxDetector::create_box()
     world_material->SetName("Pb");
 
     // Size of World volume
-    const double world_size = 500 * m;
+    double const world_size = 500 * m;
 
     // Solid
     G4Box* world_box
         = new G4Box("world_box", world_size, world_size, world_size);
 
     // Logical volume
-    const auto world_lv
+    auto const world_lv
         = new G4LogicalVolume(world_box, world_material, "world");
 
     // Physical volume
-    const auto world_pv = new G4PVPlacement(0,               // Rotation matrix
-                                            G4ThreeVector(), // Position
-                                            world_lv,        // Current LV
-                                            "world_pv",      // Name
-                                            nullptr,         // Mother LV
-                                            false,           // Bool operation
-                                            0,               // Copy number
-                                            false);          // Overlap check
+    auto const world_pv = new G4PVPlacement(0,  // Rotation matrix
+                                            G4ThreeVector(),  // Position
+                                            world_lv,  // Current LV
+                                            "world_pv",  // Name
+                                            nullptr,  // Mother LV
+                                            false,  // Bool operation
+                                            0,  // Copy number
+                                            false);  // Overlap check
 
     return world_pv;
 }
@@ -91,7 +91,7 @@ G4VPhysicalVolume* BoxDetector::create_box()
 /*!
  * Set up world box as a sensitive detector.
  */
-void BoxDetector::set_sd()
+void Box::set_sd()
 {
     auto world_sd = new SensitiveDetector("world_sd");
     G4SDManager::GetSDMpointer()->AddNewDetector(world_sd);

--- a/gdml-generator/src/Box.hh
+++ b/gdml-generator/src/Box.hh
@@ -1,9 +1,9 @@
 //----------------------------------*-C++-*----------------------------------//
-// Copyright 2024-2025 UT-Battelle, LLC, and other Celeritas developers.
+// Copyright 2022-2023 UT-Battelle, LLC, and other Celeritas developers.
 // See the top-level COPYRIGHT file for details.
 // SPDX-License-Identifier: (Apache-2.0 OR MIT)
 //---------------------------------------------------------------------------//
-//! \file BoxDetector.hh
+//! \file Box.hh
 //! \brief Create the detector geometry.
 //---------------------------------------------------------------------------//
 #pragma once
@@ -17,26 +17,21 @@
 /*!
  * Construct a programmatic detector geometry.
  */
-class ThinSlabDetector : public G4VUserDetectorConstruction
+class Box : public G4VUserDetectorConstruction
 {
   public:
     // Construct
-    ThinSlabDetector();
+    Box();
 
     // Construct geometry
     G4VPhysicalVolume* Construct() final;
+
     // Set up sensitive detectors and magnetic field
     void ConstructSDandField() final;
 
   private:
-    struct SlabDefinition
-    {
-        G4Material* material;
-        std::array<double, 3> dimension;
-    };
-
-    // Thin slab for MSC validation
-    G4VPhysicalVolume* create_slab(SlabDefinition const& def);
+    // "Infinite" box: Pb cube with 500 m side
+    G4VPhysicalVolume* create_box();
     // Set volume as sensitive detector
     void set_sd();
 };

--- a/gdml-generator/src/BoxDetector.hh
+++ b/gdml-generator/src/BoxDetector.hh
@@ -9,9 +9,9 @@
 #pragma once
 
 #include <string>
-#include <G4VUserDetectorConstruction.hh>
 #include <G4Material.hh>
 #include <G4VPhysicalVolume.hh>
+#include <G4VUserDetectorConstruction.hh>
 
 //---------------------------------------------------------------------------//
 /*!
@@ -25,6 +25,7 @@ class BoxDetector : public G4VUserDetectorConstruction
 
     // Construct geometry
     G4VPhysicalVolume* Construct() final;
+
     // Set up sensitive detectors and magnetic field
     void ConstructSDandField() final;
 

--- a/gdml-generator/src/FourSteelSlabs.cc
+++ b/gdml-generator/src/FourSteelSlabs.cc
@@ -11,6 +11,7 @@
 #include <G4LogicalVolume.hh>
 #include <G4NistManager.hh>
 #include <G4PVPlacement.hh>
+#include <G4SDManager.hh>
 #include <G4SystemOfUnits.hh>
 
 #include "core/SensitiveDetector.hh"
@@ -28,6 +29,15 @@ FourSteelSlabs::FourSteelSlabs() {}
 G4VPhysicalVolume* FourSteelSlabs::Construct()
 {
     return this->create_geometry();
+}
+
+//---------------------------------------------------------------------------//
+/*!
+ * Set sensitive detectors.
+ */
+void FourSteelSlabs::ConstructSDandField()
+{
+    this->set_sd();
 }
 
 //---------------------------------------------------------------------------//
@@ -56,78 +66,60 @@ G4VPhysicalVolume* FourSteelSlabs::create_geometry()
     auto const world_solid
         = new G4Box("world_box", half_world, half_world, half_world);
 
-    auto const world_log_vol
+    auto const world_lv
         = new G4LogicalVolume(world_solid, world_material, "world_lv");
 
-    auto const world_phys_vol = new G4PVPlacement(nullptr,
-                                                  G4ThreeVector(),
-                                                  world_log_vol,
-                                                  "world_pv",
-                                                  nullptr,
-                                                  false,
-                                                  0,
-                                                  true);
+    auto const world_pv = new G4PVPlacement(
+        nullptr, G4ThreeVector(), world_lv, "world_pv", nullptr, false, 0, true);
 
     // Slabs definition
     auto const slabs_xy = 0.01 * world_size;
     auto const slabs_z = 0.2 * slabs_xy;
-
-    // Slab 0
     auto const slab_solid = new G4Box("box", slabs_xy, slabs_xy, slabs_z);
+    auto const slab_lv
+        = new G4LogicalVolume(slab_solid, slab_material, "box_lv");
 
-    auto const slab_log_vol
-        = new G4LogicalVolume(slab_solid, slab_material, "box");
-
+    // Placements
     new G4PVPlacement(
-        0, G4ThreeVector(), slab_log_vol, "box", world_log_vol, false, 0, true);
-
-    // Slab 1
-    auto const slab_replica_solid
-        = new G4Box("boxReplica", slabs_xy, slabs_xy, slabs_z);
-
-    auto const slab_replica_log_vol
-        = new G4LogicalVolume(slab_replica_solid, slab_material, "boxReplica");
+        nullptr, G4ThreeVector(), slab_lv, "box0_pv", world_lv, false, 0, true);
 
     new G4PVPlacement(nullptr,
                       G4ThreeVector(0, 0, 3 * slabs_z),
-                      slab_replica_log_vol,
-                      "box",
-                      world_log_vol,
+                      slab_lv,
+                      "box1_pv",
+                      world_lv,
                       false,
                       0,
                       true);
-
-    // Slab 2
-    auto const slab_replica_2_solid
-        = new G4Box("boxReplica2", slabs_xy, slabs_xy, slabs_z);
-
-    auto const slab_replica_2_log_vol = new G4LogicalVolume(
-        slab_replica_2_solid, slab_material, "boxReplica");
 
     new G4PVPlacement(nullptr,
                       G4ThreeVector(0, 0, 6 * slabs_z),
-                      slab_replica_2_log_vol,
-                      "box",
-                      world_log_vol,
+                      slab_lv,
+                      "box2_pv",
+                      world_lv,
                       false,
                       0,
                       true);
-
-    // Slab 3
-    auto const slab_replica_3_solid
-        = new G4Box("boxReplica3", slabs_xy, slabs_xy, slabs_z);
-
-    auto const slab_replica_3_log_vol = new G4LogicalVolume(
-        slab_replica_3_solid, slab_material, "boxReplica");
 
     new G4PVPlacement(nullptr,
                       G4ThreeVector(0, 0, 9 * slabs_z),
-                      slab_replica_3_log_vol,
-                      "box",
-                      world_log_vol,
+                      slab_lv,
+                      "box3_pv",
+                      world_lv,
                       false,
                       0,
                       true);
 
-    return world_phys_vol;
+    return world_pv;
+}
+
+//---------------------------------------------------------------------------//
+/*!
+ * Set the 4 slab as a sensitive detectors.
+ */
+void FourSteelSlabs::set_sd()
+{
+    auto sd = new SensitiveDetector("box_sd");
+    G4VUserDetectorConstruction::SetSensitiveDetector("box_lv", sd);
+    G4SDManager::GetSDMpointer()->AddNewDetector(sd);
 }

--- a/gdml-generator/src/FourSteelSlabs.hh
+++ b/gdml-generator/src/FourSteelSlabs.hh
@@ -26,7 +26,12 @@ class FourSteelSlabs : public G4VUserDetectorConstruction
     // Construct geometry
     G4VPhysicalVolume* Construct() final;
 
+    // Set up sensitive detectors and magnetic field
+    void ConstructSDandField() final;
+
   private:
     // Four stainless-steel slabs in a vacuum
     G4VPhysicalVolume* create_geometry();
+    // Set volume as sensitive detector
+    void set_sd();
 };

--- a/gdml-generator/src/OpticalBoxes.cc
+++ b/gdml-generator/src/OpticalBoxes.cc
@@ -3,9 +3,9 @@
 // See the top-level COPYRIGHT file for details.
 // SPDX-License-Identifier: (Apache-2.0 OR MIT)
 //---------------------------------------------------------------------------//
-//! \file OpticalDetector.cc
+//! \file OpticalBoxes.cc
 //---------------------------------------------------------------------------//
-#include "OpticalDetector.hh"
+#include "OpticalBoxes.hh"
 
 #include <G4Box.hh>
 #include <G4LogicalVolume.hh>
@@ -21,13 +21,13 @@
 /*!
  * Construct empty.
  */
-OpticalDetector::OpticalDetector() {}
+OpticalBoxes::OpticalBoxes() {}
 
 //---------------------------------------------------------------------------//
 /*!
  * Mandatory Construct function.
  */
-G4VPhysicalVolume* OpticalDetector::Construct()
+G4VPhysicalVolume* OpticalBoxes::Construct()
 {
     return this->create_geometry();
 }
@@ -36,7 +36,7 @@ G4VPhysicalVolume* OpticalDetector::Construct()
 /*!
  * Set sensitive detectors and (TODO) magnetic field.
  */
-void OpticalDetector::ConstructSDandField()
+void OpticalBoxes::ConstructSDandField()
 {
     this->set_sd();
 }
@@ -50,7 +50,7 @@ void OpticalDetector::ConstructSDandField()
  * Programmatic geometry definition: Set of cubes with different optical
  * properties.
  */
-G4VPhysicalVolume* OpticalDetector::create_geometry()
+G4VPhysicalVolume* OpticalBoxes::create_geometry()
 {
     //// World ////
 
@@ -97,7 +97,7 @@ G4VPhysicalVolume* OpticalDetector::create_geometry()
 /*!
  * Flag sensitive detectors accordingly.
  */
-void OpticalDetector::set_sd()
+void OpticalBoxes::set_sd()
 {
     auto scint_sd = new SensitiveDetector("scint_sd");
     G4SDManager::GetSDMpointer()->AddNewDetector(scint_sd);
@@ -115,7 +115,7 @@ void OpticalDetector::set_sd()
  * the README table. The spectrum can be visualized at
  * https://neutrino.erciyes.edu.tr/SSLG4/ .
  */
-G4Material* OpticalDetector::scint_material()
+G4Material* OpticalBoxes::scint_material()
 {
     auto nist = G4NistManager::Instance();
     assert(nist);
@@ -151,9 +151,9 @@ G4Material* OpticalDetector::scint_material()
  * Return mass fraction of a given element given the atom density of the
  * element in the material and the material density.
  */
-double OpticalDetector::to_mass_fraction(std::string element_name,
-                                         double atom_density,
-                                         double material_density)
+double OpticalBoxes::to_mass_fraction(std::string element_name,
+                                      double atom_density,
+                                      double material_density)
 {
     assert(!element_name.empty());
     assert(atom_density > 0);
@@ -177,7 +177,7 @@ double OpticalDetector::to_mass_fraction(std::string element_name,
  * the README table. The spectrum can be visualized at
  * https://neutrino.erciyes.edu.tr/SSLG4/ .
  */
-OpticalDetector::Table OpticalDetector::scint_comp()
+OpticalBoxes::Table OpticalBoxes::scint_comp()
 {
     size_t const num_entries = 75;
     std::array<double, num_entries> wavelength = {
@@ -221,7 +221,7 @@ OpticalDetector::Table OpticalDetector::scint_comp()
  * the README table. The spectrum can be visualized at
  * https://neutrino.erciyes.edu.tr/SSLG4/ .
  */
-OpticalDetector::Table OpticalDetector::scint_rindex()
+OpticalBoxes::Table OpticalBoxes::scint_rindex()
 {
     Table result;
     result.energy = {this->to_energy(200), this->to_energy(800)};
@@ -236,7 +236,7 @@ OpticalDetector::Table OpticalDetector::scint_rindex()
  * See Geant4's examples/extended/optical/OpNovice
  * ( \c OpNoviceDetectorConstruction::Construct )
  */
-G4Material* OpticalDetector::water_material()
+G4Material* OpticalBoxes::water_material()
 {
     auto* hydrogen = new G4Element(
         "hydrogen", "H", /* Z = */ 1, /* A = */ 1.01 * g / mole);
@@ -273,7 +273,7 @@ G4Material* OpticalDetector::water_material()
  * See Geant4's examples/extended/optical/OpNovice
  * ( \c OpNoviceDetectorConstruction::Construct )
  */
-OpticalDetector::Table OpticalDetector::water_rindex()
+OpticalBoxes::Table OpticalBoxes::water_rindex()
 {
     Table result;
     result.energy = this->water_energy_table();
@@ -292,7 +292,7 @@ OpticalDetector::Table OpticalDetector::water_rindex()
  * See Geant4's examples/extended/optical/OpNovice
  * ( \c OpNoviceDetectorConstruction::Construct )
  */
-OpticalDetector::Table OpticalDetector::water_absorption()
+OpticalBoxes::Table OpticalBoxes::water_absorption()
 {
     Table result;
     result.energy = this->water_energy_table();
@@ -310,7 +310,7 @@ OpticalDetector::Table OpticalDetector::water_absorption()
 /*!
  * Return energy bins used for water properties.
  */
-std::vector<double> OpticalDetector::water_energy_table()
+std::vector<double> OpticalBoxes::water_energy_table()
 {
     return {2.034 * eV, 2.068 * eV, 2.103 * eV, 2.139 * eV, 2.177 * eV,
             2.216 * eV, 2.256 * eV, 2.298 * eV, 2.341 * eV, 2.386 * eV,
@@ -325,7 +325,7 @@ std::vector<double> OpticalDetector::water_energy_table()
 /*!
  * Convert wavelength [nm] to energy [MeV].
  */
-double OpticalDetector::to_energy(double wavelength_nm)
+double OpticalBoxes::to_energy(double wavelength_nm)
 {
     assert(wavelength_nm >= 0);
     return CLHEP::h_Planck * CLHEP::c_light / wavelength_nm;

--- a/gdml-generator/src/OpticalBoxes.hh
+++ b/gdml-generator/src/OpticalBoxes.hh
@@ -3,7 +3,7 @@
 // See the top-level COPYRIGHT file for details.
 // SPDX-License-Identifier: (Apache-2.0 OR MIT)
 //---------------------------------------------------------------------------//
-//! \file OpticalDetector.hh
+//! \file OpticalBoxes.hh
 //! \brief Create the detector geometry.
 //---------------------------------------------------------------------------//
 #pragma once
@@ -17,11 +17,11 @@
 /*!
  * Construct a programmatic detector geometry.
  */
-class OpticalDetector : public G4VUserDetectorConstruction
+class OpticalBoxes : public G4VUserDetectorConstruction
 {
   public:
     // Construct
-    OpticalDetector();
+    OpticalBoxes();
 
     // Construct geometry
     G4VPhysicalVolume* Construct() final;

--- a/gdml-generator/src/SegmentedSimpleCms.cc
+++ b/gdml-generator/src/SegmentedSimpleCms.cc
@@ -3,10 +3,11 @@
 // See the top-level COPYRIGHT file for details.
 // SPDX-License-Identifier: (Apache-2.0 OR MIT)
 //---------------------------------------------------------------------------//
-//! \file SegmentedSimpleCmsDetector.cc
+//! \file SegmentedSimpleCms.cc
 //---------------------------------------------------------------------------//
-#include "SegmentedSimpleCmsDetector.hh"
+#include "SegmentedSimpleCms.hh"
 
+#include <cstdlib>
 #include <G4Box.hh>
 #include <G4Colour.hh>
 #include <G4LogicalVolume.hh>
@@ -16,7 +17,6 @@
 #include <G4PVReplica.hh>
 #include <G4SDManager.hh>
 #include <G4VisAttributes.hh>
-#include <cstdlib>
 
 #include "core/SensitiveDetector.hh"
 
@@ -24,8 +24,8 @@
 /*!
  * Construct with geometry type enum and number of segments.
  */
-SegmentedSimpleCmsDetector::SegmentedSimpleCmsDetector(
-    MaterialType type, SegmentDefinition segments)
+SegmentedSimpleCms::SegmentedSimpleCms(MaterialType type,
+                                       SegmentDefinition segments)
     : geometry_type_(type), num_segments_(segments)
 {
     if (num_segments_.num_r < 1 || num_segments_.num_theta < 1
@@ -43,7 +43,7 @@ SegmentedSimpleCmsDetector::SegmentedSimpleCmsDetector(
 /*!
  * Mandatory Construct function.
  */
-G4VPhysicalVolume* SegmentedSimpleCmsDetector::Construct()
+G4VPhysicalVolume* SegmentedSimpleCms::Construct()
 {
     return this->segmented_simple_cms();
 }
@@ -52,7 +52,7 @@ G4VPhysicalVolume* SegmentedSimpleCmsDetector::Construct()
 /*!
  * Set sensitive detectors and (TODO) magnetic field.
  */
-void SegmentedSimpleCmsDetector::ConstructSDandField()
+void SegmentedSimpleCms::ConstructSDandField()
 {
     this->set_sd();
 
@@ -67,8 +67,7 @@ void SegmentedSimpleCmsDetector::ConstructSDandField()
 /*!
  * Define list of materials.
  */
-SegmentedSimpleCmsDetector::MaterialList
-SegmentedSimpleCmsDetector::build_materials()
+SegmentedSimpleCms::MaterialList SegmentedSimpleCms::build_materials()
 {
     MaterialList materials;
     G4NistManager* nist = G4NistManager::Instance();
@@ -135,9 +134,9 @@ SegmentedSimpleCmsDetector::build_materials()
  * r = [77.5, 125] cm).
  *
  * The final size of each material cylinder is still identical to the
- * \c SimpleCmsDetector class.
+ * \c SimpleCms class.
  */
-G4VPhysicalVolume* SegmentedSimpleCmsDetector::segmented_simple_cms()
+G4VPhysicalVolume* SegmentedSimpleCms::segmented_simple_cms()
 {
     // World volume
     G4Box* world_def = new G4Box(
@@ -356,7 +355,7 @@ G4VPhysicalVolume* SegmentedSimpleCmsDetector::segmented_simple_cms()
 /*!
  * TODO
  */
-void SegmentedSimpleCmsDetector::set_sd()
+void SegmentedSimpleCms::set_sd()
 {
     // TODO
 }
@@ -368,13 +367,12 @@ void SegmentedSimpleCmsDetector::set_sd()
  *
  * \note Not compatible with VecGeom.
  */
-void SegmentedSimpleCmsDetector::create_segments(
-    std::string name,
-    double inner_r,
-    double outer_r,
-    G4Tubs* full_culinder_def,
-    G4LogicalVolume* full_cylinder_lv,
-    G4Material* cyl_material)
+void SegmentedSimpleCms::create_segments(std::string name,
+                                         double inner_r,
+                                         double outer_r,
+                                         G4Tubs* full_culinder_def,
+                                         G4LogicalVolume* full_cylinder_lv,
+                                         G4Material* cyl_material)
 {
     std::string name_segment = name + "_segment";
     std::string name_r = name_segment + "_r";
@@ -451,12 +449,11 @@ void SegmentedSimpleCmsDetector::create_segments(
  *
  * \note Compatible with VecGeom.
  */
-void SegmentedSimpleCmsDetector::flat_segmented_cylinder(
-    std::string name,
-    double inner_r,
-    double outer_r,
-    G4Material* material,
-    G4VPhysicalVolume* world_pv)
+void SegmentedSimpleCms::flat_segmented_cylinder(std::string name,
+                                                 double inner_r,
+                                                 double outer_r,
+                                                 G4Material* material,
+                                                 G4VPhysicalVolume* world_pv)
 {
     // Segment sizes
     double const segment_r = (outer_r - inner_r) / num_segments_.num_r;

--- a/gdml-generator/src/SegmentedSimpleCms.hh
+++ b/gdml-generator/src/SegmentedSimpleCms.hh
@@ -3,7 +3,7 @@
 // See the top-level COPYRIGHT file for details.
 // SPDX-License-Identifier: (Apache-2.0 OR MIT)
 //---------------------------------------------------------------------------//
-//! \file SegmentedSimpleCmsDetector.hh
+//! \file SegmentedSimpleCms.hh
 //! \brief Create the detector geometry.
 //---------------------------------------------------------------------------//
 #pragma once
@@ -19,7 +19,7 @@
 /*!
  * Construct a programmatic detector geometry.
  */
-class SegmentedSimpleCmsDetector : public G4VUserDetectorConstruction
+class SegmentedSimpleCms : public G4VUserDetectorConstruction
 {
   public:
     enum class MaterialType
@@ -36,7 +36,7 @@ class SegmentedSimpleCmsDetector : public G4VUserDetectorConstruction
     };
 
     // Construct with geometry type and number of segments
-    SegmentedSimpleCmsDetector(MaterialType type, SegmentDefinition segments);
+    SegmentedSimpleCms(MaterialType type, SegmentDefinition segments);
 
     // Construct geometry
     G4VPhysicalVolume* Construct() final;

--- a/gdml-generator/src/SimpleCms.cc
+++ b/gdml-generator/src/SimpleCms.cc
@@ -3,9 +3,9 @@
 // See the top-level COPYRIGHT file for details.
 // SPDX-License-Identifier: (Apache-2.0 OR MIT)
 //---------------------------------------------------------------------------//
-//! \file SimpleCmsDetector.cc
+//! \file SimpleCms.cc
 //---------------------------------------------------------------------------//
-#include "SimpleCmsDetector.hh"
+#include "SimpleCms.hh"
 
 #include <G4Box.hh>
 #include <G4Colour.hh>
@@ -22,15 +22,13 @@
 /*!
  * Construct with geometry type enum.
  */
-SimpleCmsDetector::SimpleCmsDetector(MaterialType type) : geometry_type_(type)
-{
-}
+SimpleCms::SimpleCms(MaterialType type) : geometry_type_(type) {}
 
 //---------------------------------------------------------------------------//
 /*!
  * Mandatory Construct function.
  */
-G4VPhysicalVolume* SimpleCmsDetector::Construct()
+G4VPhysicalVolume* SimpleCms::Construct()
 {
     return this->simple_cms();
 }
@@ -39,7 +37,7 @@ G4VPhysicalVolume* SimpleCmsDetector::Construct()
 /*!
  * Set sensitive detectors and (TODO) magnetic field.
  */
-void SimpleCmsDetector::ConstructSDandField()
+void SimpleCms::ConstructSDandField()
 {
     this->set_sd();
 
@@ -54,7 +52,7 @@ void SimpleCmsDetector::ConstructSDandField()
 /*!
  * Define list of materials.
  */
-SimpleCmsDetector::MaterialList SimpleCmsDetector::build_materials()
+SimpleCms::MaterialList SimpleCms::build_materials()
 {
     MaterialList materials;
     G4NistManager* nist = G4NistManager::Instance();
@@ -147,7 +145,7 @@ SimpleCmsDetector::MaterialList SimpleCmsDetector::build_materials()
  * | muon chambers                | N/A        |
  *
  */
-G4VPhysicalVolume* SimpleCmsDetector::simple_cms()
+G4VPhysicalVolume* SimpleCms::simple_cms()
 {
     // Set up material list
     MaterialList materials = this->build_materials();
@@ -299,7 +297,7 @@ G4VPhysicalVolume* SimpleCmsDetector::simple_cms()
  * The two first inner cylinders, which represent the silicon tracker and the
  * EM calorimeter, are used as sensitive scoring regions.
  */
-void SimpleCmsDetector::set_sd()
+void SimpleCms::set_sd()
 {
     // List of sensitive detectors
     auto si_tracker_sd = new SensitiveDetector("si_tracker_sd");

--- a/gdml-generator/src/SimpleCms.hh
+++ b/gdml-generator/src/SimpleCms.hh
@@ -3,7 +3,7 @@
 // See the top-level COPYRIGHT file for details.
 // SPDX-License-Identifier: (Apache-2.0 OR MIT)
 //---------------------------------------------------------------------------//
-//! \file SimpleCmsDetector.hh
+//! \file SimpleCms.hh
 //! \brief Create the detector geometry.
 //---------------------------------------------------------------------------//
 #pragma once
@@ -18,7 +18,7 @@
 /*!
  * Construct a programmatic detector geometry.
  */
-class SimpleCmsDetector : public G4VUserDetectorConstruction
+class SimpleCms : public G4VUserDetectorConstruction
 {
   public:
     enum class MaterialType
@@ -28,7 +28,7 @@ class SimpleCmsDetector : public G4VUserDetectorConstruction
     };
 
     // Construct with geometry type
-    SimpleCmsDetector(MaterialType type);
+    SimpleCms(MaterialType type);
 
     // Construct geometry
     G4VPhysicalVolume* Construct() final;

--- a/gdml-generator/src/TestEm3.cc
+++ b/gdml-generator/src/TestEm3.cc
@@ -3,17 +3,17 @@
 // See the top-level COPYRIGHT file for details.
 // SPDX-License-Identifier: (Apache-2.0 OR MIT)
 //---------------------------------------------------------------------------//
-//! \file TestEm3Detector.cc
+//! \file TestEm3.cc
 //---------------------------------------------------------------------------//
-#include "TestEm3Detector.hh"
+#include "TestEm3.hh"
 
-#include <G4NistManager.hh>
 #include <G4Box.hh>
 #include <G4LogicalVolume.hh>
-#include <G4VPhysicalVolume.hh>
+#include <G4NistManager.hh>
 #include <G4PVPlacement.hh>
 #include <G4SDManager.hh>
 #include <G4SystemOfUnits.hh>
+#include <G4VPhysicalVolume.hh>
 
 #include "core/SensitiveDetector.hh"
 
@@ -21,8 +21,7 @@
 /*!
  * Construct with material and geometry options.
  */
-TestEm3Detector::TestEm3Detector(MaterialType material_type,
-                                 GeometryType geometry_type)
+TestEm3::TestEm3(MaterialType material_type, GeometryType geometry_type)
     : material_type_(material_type), geometry_type_(geometry_type)
 {
 }
@@ -31,7 +30,7 @@ TestEm3Detector::TestEm3Detector(MaterialType material_type,
 /*!
  * Mandatory Construct function.
  */
-G4VPhysicalVolume* TestEm3Detector::Construct()
+G4VPhysicalVolume* TestEm3::Construct()
 {
     switch (geometry_type_)
     {
@@ -52,7 +51,7 @@ G4VPhysicalVolume* TestEm3Detector::Construct()
 /*!
  * Set sensitive detectors and magnetic field.
  */
-void TestEm3Detector::ConstructSDandField()
+void TestEm3::ConstructSDandField()
 {
     if (geometry_type_ == GeometryType::hierarchical)
     {
@@ -69,9 +68,9 @@ void TestEm3Detector::ConstructSDandField()
 /*!
  * Build TestEm3 materials.
  */
-TestEm3Detector::MaterialList TestEm3Detector::load_materials()
+TestEm3::MaterialList TestEm3::load_materials()
 {
-    const auto nist = G4NistManager::Instance();
+    auto const nist = G4NistManager::Instance();
 
     MaterialList list;
     list.world = nist->FindOrBuildMaterial("G4_Galactic");
@@ -109,20 +108,20 @@ TestEm3Detector::MaterialList TestEm3Detector::load_materials()
  * - AdePT's example seems to have mistakenly inverted gap/absorber materials.
  * - AdePT defines G4EmParameters::SetMscRangeFactor(0.06) here. We don't.
  */
-G4VPhysicalVolume* TestEm3Detector::create_testem3()
+G4VPhysicalVolume* TestEm3::create_testem3()
 {
-    const unsigned int num_layers        = 50;
-    const double       CalorSizeYZ       = 40 * cm;
-    const double       GapThickness      = 2.3 * mm;
-    const double       AbsorberThickness = 5.7 * mm;
+    unsigned int const num_layers = 50;
+    double const CalorSizeYZ = 40 * cm;
+    double const GapThickness = 2.3 * mm;
+    double const AbsorberThickness = 5.7 * mm;
 
-    const double LayerThickness = GapThickness + AbsorberThickness;
-    const double CalorThickness = num_layers * LayerThickness;
-    const double WorldSizeX     = 1.2 * CalorThickness;
-    const double WorldSizeYZ    = 1.2 * CalorSizeYZ;
+    double const LayerThickness = GapThickness + AbsorberThickness;
+    double const CalorThickness = num_layers * LayerThickness;
+    double const WorldSizeX = 1.2 * CalorThickness;
+    double const WorldSizeYZ = 1.2 * CalorSizeYZ;
 
     // Create materials
-    const auto materials = load_materials();
+    auto const materials = load_materials();
 
     // Define a world
     G4Box* worldBox = new G4Box(
@@ -158,7 +157,7 @@ G4VPhysicalVolume* TestEm3Detector::create_testem3()
     auto gapBox = new G4Box(
         "gapBox", 0.5 * GapThickness, 0.5 * CalorSizeYZ, 0.5 * CalorSizeYZ);
 
-    auto          gapLogic = new G4LogicalVolume(gapBox, materials.gap, "Gap");
+    auto gapLogic = new G4LogicalVolume(gapBox, materials.gap, "Gap");
     G4ThreeVector gapPlacement(
         -0.5 * LayerThickness + 0.5 * GapThickness, 0, 0);
 
@@ -177,7 +176,7 @@ G4VPhysicalVolume* TestEm3Detector::create_testem3()
     for (int i = 0; i < num_layers; i++)
     {
         std::string layerName = "Layer_" + std::to_string(i);
-        auto        layer_lv
+        auto layer_lv
             = new G4LogicalVolume(layerBox, materials.world, layerName);
 
         G4ThreeVector placement(xCenter, 0, 0);
@@ -207,7 +206,7 @@ G4VPhysicalVolume* TestEm3Detector::create_testem3()
 /*!
  * Set up TestEm3 sensitive detectors.
  */
-void TestEm3Detector::set_sd()
+void TestEm3::set_sd()
 {
     auto sd_gap = new SensitiveDetector("sd_gap");
     auto sd_abs = new SensitiveDetector("sd_absorber");
@@ -229,20 +228,20 @@ void TestEm3Detector::set_sd()
  *
  * DO NOT USE IN A COMPARISON RUN.
  */
-G4VPhysicalVolume* TestEm3Detector::create_testem3_flat()
+G4VPhysicalVolume* TestEm3::create_testem3_flat()
 {
-    const unsigned int num_layers        = 50;
-    const double       CalorSizeYZ       = 40 * cm;
-    const double       GapThickness      = 2.3 * mm;
-    const double       AbsorberThickness = 5.7 * mm;
+    unsigned int const num_layers = 50;
+    double const CalorSizeYZ = 40 * cm;
+    double const GapThickness = 2.3 * mm;
+    double const AbsorberThickness = 5.7 * mm;
 
-    const double LayerThickness = GapThickness + AbsorberThickness;
-    const double CalorThickness = num_layers * LayerThickness;
-    const double WorldSizeX     = 1.2 * CalorThickness;
-    const double WorldSizeYZ    = 1.2 * CalorSizeYZ;
+    double const LayerThickness = GapThickness + AbsorberThickness;
+    double const CalorThickness = num_layers * LayerThickness;
+    double const WorldSizeX = 1.2 * CalorThickness;
+    double const WorldSizeYZ = 1.2 * CalorSizeYZ;
 
     // Create materials
-    const auto materials = load_materials();
+    auto const materials = load_materials();
 
     // World definition and placement
     G4Box* worldBox = new G4Box(
@@ -265,7 +264,7 @@ G4VPhysicalVolume* TestEm3Detector::create_testem3_flat()
     for (int i = 0; i < num_layers; i++)
     {
         std::string absorber_name = "absorber_" + std::to_string(i);
-        std::string gap_name      = "gap_" + std::to_string(i);
+        std::string gap_name = "gap_" + std::to_string(i);
 
         auto gapLogic = new G4LogicalVolume(gapBox, materials.gap, gap_name);
         auto absorberLogic = new G4LogicalVolume(

--- a/gdml-generator/src/TestEm3.hh
+++ b/gdml-generator/src/TestEm3.hh
@@ -3,7 +3,7 @@
 // See the top-level COPYRIGHT file for details.
 // SPDX-License-Identifier: (Apache-2.0 OR MIT)
 //---------------------------------------------------------------------------//
-//! \file TestEm3Detector.hh
+//! \file TestEm3.hh
 //! \brief Create the detector geometry.
 //---------------------------------------------------------------------------//
 #pragma once
@@ -21,7 +21,7 @@ class G4Material;
  * Programmatic geometry definition taken from AdePT's repository.
  * See github.com/apt-sim/AdePT/tree/master/examples/TestEm3
  */
-class TestEm3Detector : public G4VUserDetectorConstruction
+class TestEm3 : public G4VUserDetectorConstruction
 {
   public:
     enum class MaterialType
@@ -37,7 +37,7 @@ class TestEm3Detector : public G4VUserDetectorConstruction
     };
 
     // Construct empty
-    TestEm3Detector(MaterialType material_type, GeometryType geometry_type);
+    TestEm3(MaterialType material_type, GeometryType geometry_type);
 
     // Construct geometry
     G4VPhysicalVolume* Construct() final;
@@ -66,6 +66,6 @@ class TestEm3Detector : public G4VUserDetectorConstruction
   private:
     // Assigned by create_testem3() and released ownership at Construct()
     std::unique_ptr<G4VPhysicalVolume> phys_vol_world_;
-    GeometryType                       geometry_type_;
-    MaterialType                       material_type_;
+    GeometryType geometry_type_;
+    MaterialType material_type_;
 };

--- a/gdml-generator/src/ThinSlab.cc
+++ b/gdml-generator/src/ThinSlab.cc
@@ -3,9 +3,9 @@
 // See the top-level COPYRIGHT file for details.
 // SPDX-License-Identifier: (Apache-2.0 OR MIT)
 //---------------------------------------------------------------------------//
-//! \file ThinSlabDetector.cc
+//! \file ThinSlab.cc
 //---------------------------------------------------------------------------//
-#include "ThinSlabDetector.hh"
+#include "ThinSlab.hh"
 
 #include <G4Box.hh>
 #include <G4Colour.hh>
@@ -23,7 +23,7 @@
 /*!
  * Construct empty.
  */
-ThinSlabDetector::ThinSlabDetector() {}
+ThinSlab::ThinSlab() {}
 
 //---------------------------------------------------------------------------//
 /*!
@@ -32,7 +32,7 @@ ThinSlabDetector::ThinSlabDetector() {}
  * For MSC experimental comparison, see
  * https://journals.aps.org/pr/abstract/10.1103/PhysRev.84.634
  */
-G4VPhysicalVolume* ThinSlabDetector::Construct()
+G4VPhysicalVolume* ThinSlab::Construct()
 {
     // Test targets: C, Si, Fe, Ag, Au, Pb
     auto nist = G4NistManager::Instance();
@@ -50,7 +50,7 @@ G4VPhysicalVolume* ThinSlabDetector::Construct()
 /*!
  * Set sensitive detectors.
  */
-void ThinSlabDetector::ConstructSDandField()
+void ThinSlab::ConstructSDandField()
 {
     this->set_sd();
 }
@@ -66,7 +66,7 @@ void ThinSlabDetector::ConstructSDandField()
  * The world volume material is vacuum and is is 4 times larger in the z-axis
  * than the input slab, while keeping the same size in x and y axes.
  */
-G4VPhysicalVolume* ThinSlabDetector::create_slab(SlabDefinition const& def)
+G4VPhysicalVolume* ThinSlab::create_slab(SlabDefinition const& def)
 {
     // Materials
     auto nist = G4NistManager::Instance();
@@ -94,7 +94,7 @@ G4VPhysicalVolume* ThinSlabDetector::create_slab(SlabDefinition const& def)
 /*!
  * Set up slab as a sensitive detector.
  */
-void ThinSlabDetector::set_sd()
+void ThinSlab::set_sd()
 {
     auto slab_sb = new SensitiveDetector("slab_sd");
     G4SDManager::GetSDMpointer()->AddNewDetector(slab_sb);

--- a/gdml-generator/src/ThinSlab.hh
+++ b/gdml-generator/src/ThinSlab.hh
@@ -1,9 +1,9 @@
 //----------------------------------*-C++-*----------------------------------//
-// Copyright 2022-2023 UT-Battelle, LLC, and other Celeritas developers.
+// Copyright 2024-2025 UT-Battelle, LLC, and other Celeritas developers.
 // See the top-level COPYRIGHT file for details.
 // SPDX-License-Identifier: (Apache-2.0 OR MIT)
 //---------------------------------------------------------------------------//
-//! \file BoxDetector.hh
+//! \file ThinSlab.hh
 //! \brief Create the detector geometry.
 //---------------------------------------------------------------------------//
 #pragma once
@@ -17,21 +17,26 @@
 /*!
  * Construct a programmatic detector geometry.
  */
-class BoxDetector : public G4VUserDetectorConstruction
+class ThinSlab : public G4VUserDetectorConstruction
 {
   public:
     // Construct
-    BoxDetector();
+    ThinSlab();
 
     // Construct geometry
     G4VPhysicalVolume* Construct() final;
-
     // Set up sensitive detectors and magnetic field
     void ConstructSDandField() final;
 
   private:
-    // "Infinite" box: Pb cube with 500 m side
-    G4VPhysicalVolume* create_box();
+    struct SlabDefinition
+    {
+        G4Material* material;
+        std::array<double, 3> dimension;
+    };
+
+    // Thin slab for MSC validation
+    G4VPhysicalVolume* create_slab(SlabDefinition const& def);
     // Set volume as sensitive detector
     void set_sd();
 };


### PR DESCRIPTION
- Assign sensitive detectors to the four-steel-slabs geometry.
- Simplify `DetectorConstruction` class names.