### PR TITLE
Add additional arguments to primaries-converter

### DIFF
--- a/primaries-converter/primaries-converter.cc
+++ b/primaries-converter/primaries-converter.cc
@@ -16,15 +16,19 @@
 //---------------------------------------------------------------------------//
 //! Loop over events of a given reader and write to ROOT.
 template<class T>
-void convert(T reader, RootEventWriter& writer)
+void convert(T reader, RootEventWriter& writer, size_t max_events)
 {
+    size_t count = 0;
     for ([[maybe_unused]] auto i : celeritas::range(reader.num_events()))
     {
+        if (max_events && count >= max_events)
+            break;
+
         writer(reader());
+        ++count;
     }
 
-    CELER_LOG(info) << "Wrote " << reader.num_events()
-                    << " event(s) to ROOT file.";
+    CELER_LOG(info) << "Wrote " << count << " event(s) to ROOT file.";
 }
 
 //---------------------------------------------------------------------------//
@@ -35,12 +39,45 @@ int main(int argc, char* argv[])
 {
     if (argc == 1)
     {
-        std::cout << "Usage: " << argv[0] << " input.[hepmc3/jsonl]"
+        std::cout << "Usage: " << argv[0]
+                  << " input.[hepmc3/jsonl] [-n max_events] [-o output.root]"
                   << std::endl;
         return EXIT_FAILURE;
     }
 
     std::string input = argv[1];
+    size_t max_events = 0;
+    std::string root_filename;
+
+    for (int i = 2; i < argc; ++i)
+    {
+        std::string arg = argv[i];
+        if (arg == "-n")
+        {
+            if (i + 1 >= argc)
+            {
+                std::cout << "Error: missing value for " << arg << std::endl;
+                return EXIT_FAILURE;
+            }
+            max_events = std::stoull(argv[++i]);
+        }
+        else if (arg == "-o")
+        {
+            if (i + 1 >= argc)
+            {
+                std::cout << "Error: missing value for " << arg << std::endl;
+                return EXIT_FAILURE;
+            }
+            root_filename = argv[++i];
+        }
+        else
+        {
+            std::cout << "Error: unrecognized argument '" << arg << "'"
+                      << std::endl;
+            return EXIT_FAILURE;
+        }
+    }
+
     std::string extension = input.substr(input.find_last_of(".") + 1);
 
     if (extension != "hepmc3" && extension != "jsonl")
@@ -50,17 +87,21 @@ int main(int argc, char* argv[])
         return EXIT_FAILURE;
     }
 
-    // Create ROOT file
-    std::string root_filename = input.substr(0, input.find_last_of("."));
-    root_filename += ".root";
+    // Create ROOT file (default: input basename + ".root")
+    if (root_filename.empty())
+    {
+        root_filename = input.substr(0, input.find_last_of("."));
+        root_filename += ".root";
+    }
     auto sp_rfm
         = std::make_shared<celeritas::RootFileManager>(root_filename.c_str());
     sp_rfm->make_tree("primaries", "primaries");
     RootEventWriter write_to_root(sp_rfm);
 
     // Write primaries to ROOT
-    (extension == "hepmc3") ? convert(EventReader(input), write_to_root)
-                            : convert(JsonEventReader(input), write_to_root);
+    (extension == "hepmc3")
+        ? convert(EventReader(input), write_to_root, max_events)
+        : convert(JsonEventReader(input), write_to_root, max_events);
 
     return EXIT_SUCCESS;
 }

--- a/primaries-converter/primaries-converter.cc
+++ b/primaries-converter/primaries-converter.cc
@@ -37,7 +37,7 @@ void convert(T reader, RootEventWriter& writer, size_t max_events)
  */
 int main(int argc, char* argv[])
 {
-    if (argc == 1)
+    if (argc == 1 || argc > 6)
     {
         std::cout << "Usage: " << argv[0]
                   << " input.[hepmc3/jsonl] [-n max_events] [-o output.root]"


### PR DESCRIPTION
This adds two additional arguments to `primaries-converter`:

1) specify a maximum number of events to write,
2) specify the output file name.