### PR TITLE
Add Notional DUNE model

### DIFF
--- a/gdml-generator/CMakeLists.txt
+++ b/gdml-generator/CMakeLists.txt
@@ -36,6 +36,7 @@ add_executable(gdml-gen gdml-gen.cc
   src/ThinSlab.cc
   src/SimpleLZ.cc
   src/NotionalJUNO.cc
+  src/NotionalDUNE.cc
 )
 
 target_compile_features(gdml-gen

--- a/gdml-generator/README.md
+++ b/gdml-generator/README.md
@@ -43,6 +43,7 @@ The available geometries are:
 | 14   | Muon-catalyzed fusion dt target only |
 | 15   | Optical prism |
 | 16   | Notional JUNO model |
+| 17   | Notional DUNE model |
 
 [testem3]: https://github.com/apt-sim/AdePT/tree/master/examples/TestEm3
 

--- a/gdml-generator/gdml-gen.cc
+++ b/gdml-generator/gdml-gen.cc
@@ -27,6 +27,7 @@
 #include "FourSteelSlabs.hh"
 #include "MucfBox.hh"
 #include "MucfTestGeo.hh"
+#include "NotionalDUNE.hh"
 #include "NotionalJUNO.hh"
 #include "OpticalBoxes.hh"
 #include "OpticalPrism.hh"
@@ -61,6 +62,7 @@ enum class GeometryID
     mucf_box,  //!< Muon-catalyzed fusion box target only
     optical_prism,  //!< Triangular prism with optical properties
     notional_juno,  //!< Notional model of the JUNO experiement
+    notional_dune,  //!< Notional model of the DUNE experiement
     size_
 };
 
@@ -76,55 +78,41 @@ constexpr char const* label(GeometryID id) noexcept
     {
         case GID::box:
             return "Lead box";
-            break;
         case GID::four_steel_slabs:
             return "Four steel slabs";
-            break;
         case GID::simple_cms:
             return "Simple CMS - simple materials";
-            break;
         case GID::simple_cms_composite:
             return "Simple CMS - composite materials";
-            break;
         case GID::segmented_simple_cms:
             return "Segmented Simple CMS - simple materials";
-            break;
         case GID::segmented_simple_cms_composite:
             return "Segmented Simple CMS - composite materials";
-            break;
         case GID::testem3:
             return "TestEm3 - simple materials";
-            break;
         case GID::testem3_composite:
             return "TestEm3 - composite materials";
-            break;
         case GID::testem3_flat:
             return "TestEm3 flat - simple materials, for ORANGE";
-            break;
         case GID::testem3_composite_flat:
             return "TestEm3 flat - composite materials, for ORANGE";
-            break;
         case GID::optical_boxes:
             return "Optical boxes - composite material boxes with optical "
                    "properties";
-            break;
         case GID::thin_slab:
             return "Thin Pb slab";
-            break;
         case GID::simple_lz:
             return "Simplified LZ - top PMT array";
-            break;
         case GID::mucf_test_geo:
             return "MuCF test geometry - dt target and neutron counters";
-            break;
         case GID::mucf_box:
             return "MuCF box target only";
-            break;
         case GID::optical_prism:
             return "Optical triangular prism";
         case GID::notional_juno:
             return "Notional model of JUNO";
-            break;
+        case GID::notional_dune:
+            return "Notional model of DUNE";
         default:
             __builtin_unreachable();
     }
@@ -162,6 +150,10 @@ void print_help(char const* argv)
          << endl;
     cout << "3 extra parameters are needed [device_radius], "
             "[pmt_radius], [num_pmts]"
+         << endl;
+    cout << "For " << static_cast<int>(GeometryID::notional_dune) << ":"
+         << endl;
+    cout << "2 extra parameters are needed [num_spheres] and [num_levels] "
          << endl;
 }
 
@@ -216,26 +208,12 @@ void export_gdml(std::string const& gdml_filename)
  */
 int main(int argc, char* argv[])
 {
-    if (argc != 2 && argc != 3 && argc != 5)
-    {
-        print_help(argv[0]);
-        return EXIT_FAILURE;
-    }
-
     // Load input parameters
     auto const geometry_id = static_cast<GeometryID>(std::stoi(argv[1]));
     if (geometry_id >= GeometryID::size_)
     {
         std::cout << static_cast<int>(geometry_id)
                   << " is an invalid geometry id." << std::endl;
-        return EXIT_FAILURE;
-    }
-    if (geometry_id != GeometryID::segmented_simple_cms
-        && geometry_id != GeometryID::segmented_simple_cms_composite
-        && geometry_id != GeometryID::simple_lz && argc != 2
-        && geometry_id != GeometryID::notional_juno && argc != 5)
-    {
-        std::cout << "Wrong number of arguments" << std::endl;
         return EXIT_FAILURE;
     }
 
@@ -279,12 +257,26 @@ int main(int argc, char* argv[])
             break;
 
         case GeometryID::segmented_simple_cms:
+            if (argc != 5)
+            {
+                std::cout
+                    << "Segmented Simple CMS requires 3 additional arguments "
+                    << std::endl;
+                return EXIT_FAILURE;
+            }
             run_manager->SetUserInitialization(new SegmentedSimpleCms(
                 SCMSType::simple, get_segments(argc, argv)));
             gdml_filename = "segmented-simple-cms.gdml";
             break;
 
         case GeometryID::segmented_simple_cms_composite:
+            if (argc != 5)
+            {
+                std::cout
+                    << "Segmented Simple CMS requires 3 additional arguments "
+                    << std::endl;
+                return EXIT_FAILURE;
+            }
             run_manager->SetUserInitialization(new SegmentedSimpleCms(
                 SCMSType::composite, get_segments(argc, argv)));
             gdml_filename = "composite-segmented-simple-cms.gdml";
@@ -379,6 +371,36 @@ int main(int argc, char* argv[])
             else
             {
                 std::cout << "NotionalJUNO requires 3 additional arguments "
+                          << std::endl;
+                return EXIT_FAILURE;
+            }
+        case GeometryID::notional_dune:
+            gdml_filename = "notional_dune.gdml";
+            if (argc == 4)
+            {
+                int num_spheres = std::stoi(argv[2]);
+                int num_levels = std::stoi(argv[3]);
+
+                if (num_spheres <= 0)
+                {
+                    std::cout << "num_spheres must be positive " << std::endl;
+                    return EXIT_FAILURE;
+                }
+                if (num_levels < 0)
+                {
+                    std::cout
+                        << "The number of levels must be non-negative "
+                        << std::endl;
+                    return EXIT_FAILURE;
+                }
+
+                run_manager->SetUserInitialization(
+                    new NotionalDUNE(num_spheres, num_levels));
+                break;
+            }
+            else
+            {
+                std::cout << "NotionalDUNE requires 2 additional arguments "
                           << std::endl;
                 return EXIT_FAILURE;
             }

--- a/gdml-generator/src/NotionalDUNE.cc
+++ b/gdml-generator/src/NotionalDUNE.cc
@@ -1,0 +1,133 @@
+//----------------------------------*-C++-*----------------------------------//
+// Copyright 2024-2025 UT-Battelle, LLC, and other Celeritas developers.
+// See the top-level COPYRIGHT file for details.
+// SPDX-License-Identifier: (Apache-2.0 OR MIT)
+//---------------------------------------------------------------------------//
+//! \file NotionalDUNE.cc
+//---------------------------------------------------------------------------//
+#include "NotionalDUNE.hh"
+
+#include <G4Box.hh>
+#include <G4LogicalVolume.hh>
+#include <G4NistManager.hh>
+#include <G4Orb.hh>
+#include <G4PVPlacement.hh>
+#include <G4SDManager.hh>
+#include <G4SystemOfUnits.hh>
+#include <G4ThreeVector.hh>
+
+#include "core/SensitiveDetector.hh"
+
+//---------------------------------------------------------------------------//
+/*!
+ * Constructor.
+ */
+NotionalDUNE::NotionalDUNE(int num_spheres_per_axis, int num_levels)
+    : num_spheres_per_axis_(num_spheres_per_axis)
+    , num_levels_(num_levels)
+{
+}
+
+//---------------------------------------------------------------------------//
+/*!
+ * Build a notional DUNE geometry.
+ */
+G4VPhysicalVolume* NotionalDUNE::Construct()
+{
+    // Materials
+    auto nist = G4NistManager::Instance();
+    // Bulk medium of the TPC: liquid argon
+    auto lar_mat = nist->FindOrBuildMaterial("G4_lAr");
+    // Anode material. Copper is used as a representative stand-in
+    auto anode_mat = nist->FindOrBuildMaterial("G4_Cu");
+    // Everything outside the active volume (world + concentric shells): vacuum
+    auto world_mat = nist->FindOrBuildMaterial("G4_Galactic");
+    world_mat->SetName("vacuum");
+
+    // World: large enough to enclose the outermost concentric box, with one
+    // extra layer of vacuum margin so nothing is tangent to the world boundary
+    double const outer_edge = box_size_ + 2.0 * num_levels_ * level_thickness_;
+    double const world_edge = outer_edge + 2.0 * level_thickness_;
+    G4Box* world_box = new G4Box("world_box",
+                                 0.5 * world_edge * cm,
+                                 0.5 * world_edge * cm,
+                                 0.5 * world_edge * cm);
+    auto const world_lv = new G4LogicalVolume(world_box, world_mat, "world");
+    auto const world_pv = new G4PVPlacement(
+        nullptr, G4ThreeVector(), world_lv, "world_pv", nullptr, false, 0, false);
+
+    // Concentric vacuum boxes, built from the outermost (level M) inward so
+    // that each shell is placed inside the next-larger one. 
+    auto mother_lv = world_lv;
+    for (int level = num_levels_; level >= 1; --level)
+    {
+        double const edge = box_size_ + 2.0 * level * level_thickness_;
+        G4Box* shell_box = new G4Box(
+            "shell_box", 0.5 * edge * cm, 0.5 * edge * cm, 0.5 * edge * cm);
+        auto const shell_lv
+            = new G4LogicalVolume(shell_box, world_mat, "shell_lv");
+        new G4PVPlacement(nullptr,
+                          G4ThreeVector(),
+                          shell_lv,
+                          "shell_pv",
+                          mother_lv,
+                          false,
+                          level,
+                          false);
+        mother_lv = shell_lv;
+    }
+
+    // Central liquid-argon box that holds the grid of anode spheres.
+    // Placed in the innermost shell, or directly in the world when
+    // num_levels_ == 0.
+    G4Box* inner_box = new G4Box("inner_box",
+                                 0.5 * box_size_ * cm,
+                                 0.5 * box_size_ * cm,
+                                 0.5 * box_size_ * cm);
+    auto const inner_lv = new G4LogicalVolume(inner_box, lar_mat, "inner_lv");
+    new G4PVPlacement(
+        nullptr, G4ThreeVector(), inner_lv, "inner_pv", mother_lv, false, 0, false);
+
+    // Grid of N^3 "anode" spheres, equally spaced and symmetric about the 
+    // origin.
+    double const pitch = box_size_ / num_spheres_per_axis_;
+    double const offset = -0.5 * box_size_ + 0.5 * pitch;
+
+    G4Orb* sphere = new G4Orb("sphere", sphere_radius_ * cm);
+    auto const sphere_lv = new G4LogicalVolume(sphere, anode_mat, "sphere_lv");
+
+    int copy_no = 0;
+    for (int i = 0; i < num_spheres_per_axis_; ++i)
+    {
+        for (int j = 0; j < num_spheres_per_axis_; ++j)
+        {
+            for (int k = 0; k < num_spheres_per_axis_; ++k)
+            {
+                G4ThreeVector pos((offset + i * pitch) * cm,
+                                  (offset + j * pitch) * cm,
+                                  (offset + k * pitch) * cm);
+                new G4PVPlacement(nullptr,
+                                  pos,
+                                  sphere_lv,
+                                  "sphere_pv",
+                                  inner_lv,
+                                  false,
+                                  copy_no++,
+                                  false);
+            }
+        }
+    }
+
+    return world_pv;
+}
+
+//---------------------------------------------------------------------------//
+/*!
+ * Set the bulk liquid-argon as the sensitive detector.
+ */
+void NotionalDUNE::ConstructSDandField()
+{
+    auto lar_sd = new SensitiveDetector("lar_sd");
+    G4SDManager::GetSDMpointer()->AddNewDetector(lar_sd);
+    G4VUserDetectorConstruction::SetSensitiveDetector("inner_lv", lar_sd);
+}

--- a/gdml-generator/src/NotionalDUNE.hh
+++ b/gdml-generator/src/NotionalDUNE.hh
@@ -1,0 +1,43 @@
+//----------------------------------*-C++-*----------------------------------//
+// Copyright 2024-2026 UT-Battelle, LLC, and other Celeritas developers.
+// See the top-level COPYRIGHT file for details.
+// SPDX-License-Identifier: (Apache-2.0 OR MIT)
+//---------------------------------------------------------------------------//
+//! \file NotionalDUNE.hh
+//---------------------------------------------------------------------------//
+#pragma once
+
+#include <G4VUserDetectorConstruction.hh>
+
+class G4VPhysicalVolume;
+
+//---------------------------------------------------------------------------//
+/*!
+ * Construct a notional DUNE geometry.
+ *
+ * A central 1 m x 1 m x 1 m cube of liquid argon, centered at the origin, is
+ * filled with a regular N x N x N grid of equally spaced spheres as backgroud
+ * volume stand-ins for the anode. The liquid-argon volume is then nested inside
+ * M successively larger concentric vacuum boxes, each adding
+ * level_thickness of wall on every side.
+ */
+class NotionalDUNE final : public G4VUserDetectorConstruction
+{
+  public:
+    NotionalDUNE(int num_spheres_per_axis, int num_levels);
+
+    G4VPhysicalVolume* Construct() final;
+    void ConstructSDandField() final;
+
+  private:
+    //! Edge length of the central liquid-argon box [cm]
+    static constexpr double box_size_ = 100;
+    //! Radius of each "anode" sphere [cm]
+    static constexpr double sphere_radius_ = 0.25;
+    //! Wall thickness added per concentric vacuum level [cm]
+    static constexpr double level_thickness_ = 1;
+    //! Spheres per axis (N), N^3 spheres total
+    int num_spheres_per_axis_;
+    //! Number of concentric outer vacuum boxes (M)
+    int num_levels_;
+};


### PR DESCRIPTION
This MR adds a notional model of DUNE, which will be used to test how state size affects runtime. It consists of a liquid argon cube with N^3 spheres of copper, and M concentric vacuum boxes. The copper spheres are daughters in the background volume, as the anode is in the actual model. The concentric vacuum boxes do not affect the transport results, be each layer adds depth to the nested structure of universes thereby increasing the state size. The image below shows GDML output with 1000 spheres within three concentric vacuum boxes.

<img width="641" height="606" alt="Screenshot 2026-06-24 at 5 04 19 PM" src="https://github.com/user-attachments/assets/0a5a4a61-b29c-448c-a688-f3b1858de3b9" />